### PR TITLE
Crash fix for non-Windows systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT WIN32)
   add_options(ALL_LANGUAGES ALL_BUILDS "-fPIC")
 endif()
 
+# Source files
 set(ARGUSTV_SOURCES src/activerecording.cpp
                     src/argustvrpc.cpp
                     src/channel.cpp
@@ -32,6 +33,36 @@ set(ARGUSTV_SOURCES src/activerecording.cpp
                     src/upcomingrecording.cpp
                     src/uri.cpp
                     src/utils.cpp)
+
+# Header files
+set(ARGUSTV_HEADERS src/activerecording.h
+                    src/argustvrpc.h
+                    src/channel.h
+                    src/client.h
+                    src/epg.h
+                    src/EventsThread.h
+                    src/guideprogram.h
+                    src/KeepAliveThread.h
+                    src/pvrclient-argustv.h
+                    src/recording.h
+                    src/recordinggroup.h
+                    src/tools.h
+                    src/upcomingrecording.h
+                    src/uri.h
+                    src/utils.h)
+source_group("Header Files" FILES ${ARGUSTV_HEADERS})
+
+if(WIN32)
+# Misc files
+set(RESOURCE_FILES pvr.argustv/addon.xml
+                pvr.argustv/changelog.txt
+                pvr.argustv/resources/settings.xml
+                pvr.argustv/resources/language/English/strings.po)
+source_group("Resource Files" FILES ${RESOURCE_FILES})
+endif(WIN32)
+
+# Make sure that CMake adds the headers to the MSVC project
+list(APPEND ARGUSTV_SOURCES ${ARGUSTV_HEADERS} ${RESOURCE_FILES})
 
 set(DEPLIBS ${kodiplatform_LIBRARIES} tsreader)
 

--- a/pvr.argustv/addon.xml
+++ b/pvr.argustv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.10.2"
+  version="1.10.3"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,7 @@
+v1.10.3 (14-03-2015)
+-  TSReader: attempt to fix a crash on RPi due to xbmc/xbmc#6306
+   This PR introduced a 2nd FileReader class in Kodi which conflicts with the PVR addon one...
+   The PVR FileReader class is now inside an ArgusTV namespace
 v1.10.2 (08-03-2015)
  - Updated to PVR API v1.9.5
 v1.10.1 (17-02-2015)

--- a/src/lib/tsreader/CMakeLists.txt
+++ b/src/lib/tsreader/CMakeLists.txt
@@ -4,8 +4,16 @@ ENABLE_LANGUAGE(CXX)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
+# Source files
 SET(SOURCES FileReader.cpp
             MultiFileReader.cpp
             TSReader.cpp)
 
-ADD_LIBRARY(tsreader STATIC ${SOURCES})
+# Header files
+SET(HEADERS FileReader.h
+            MultiFileReader.h
+            TSReader.h)
+
+SOURCE_GROUP("Header Files" FILES ${HEADERS})
+
+ADD_LIBRARY(tsreader STATIC ${HEADERS} ${SOURCES})

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -39,190 +39,193 @@
 
 using namespace ADDON;
 
-/* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
+namespace ArgusTV
+{
+
+  /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
 #define READ_TRUNCATED 0x01
 
-/* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
+  /* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
 #define READ_CHUNKED   0x02
 
-/* use cache to access this file */
+  /* use cache to access this file */
 #define READ_CACHED     0x04
 
-/* open without caching. regardless to file type. */
+  /* open without caching. regardless to file type. */
 #define READ_NO_CACHE  0x08
 
-/* calcuate bitrate for file while reading */
+  /* calcuate bitrate for file while reading */
 #define READ_BITRATE   0x10
 
-FileReader::FileReader() :
-  m_hFile(NULL),
-  m_pFileName(0),
-  m_fileSize(0),
-  m_fileStartPos(0),
-  m_bDebugOutput(false)
-{
-}
-
-FileReader::~FileReader()
-{
-  CloseFile();
-  if (m_pFileName)
-    delete m_pFileName;
-}
-
-
-long FileReader::GetFileName(char* *lpszFileName)
-{
-  *lpszFileName = m_pFileName;
-  return S_OK;
-}
-
-
-long FileReader::SetFileName(const char *pszFileName)
-{
-  if(strlen(pszFileName) > MAX_PATH)
-    return ERROR_FILENAME_EXCED_RANGE;
-
-  // Take a copy of the filename
-  if (m_pFileName)
+  FileReader::FileReader() :
+    m_hFile(NULL),
+    m_pFileName(0),
+    m_fileSize(0),
+    m_fileStartPos(0),
+    m_bDebugOutput(false)
   {
-    delete[] m_pFileName;
-    m_pFileName = NULL;
   }
 
-  m_pFileName = new char[1 + strlen(pszFileName)];
-  if (m_pFileName == NULL)
-    return E_OUTOFMEMORY;
-
-  strncpy(m_pFileName, pszFileName, strlen(pszFileName) + 1);
-
-  return S_OK;
-}
-
-//
-// OpenFile
-//
-// Opens the file ready for streaming
-//
-long FileReader::OpenFile()
-{
-  int Tmo = 25; //5 in MediaPortal
-
-  // Is the file already opened
-  if (!IsFileInvalid())
+  FileReader::~FileReader()
   {
-    XBMC->Log(LOG_NOTICE, "FileReader::OpenFile() file already open");
+    CloseFile();
+    if (m_pFileName)
+      delete m_pFileName;
+  }
+
+
+  long FileReader::GetFileName(char* *lpszFileName)
+  {
+    *lpszFileName = m_pFileName;
     return S_OK;
   }
 
-  // Has a filename been set yet
-  if (m_pFileName == NULL) 
-  {
-    XBMC->Log(LOG_ERROR, "FileReader::OpenFile() no filename");
-    return ERROR_INVALID_NAME;
-  }
 
-  XBMC->Log(LOG_DEBUG, "FileReader::OpenFile() Trying to open %s\n", m_pFileName);
-
-  do
+  long FileReader::SetFileName(const char *pszFileName)
   {
-    XBMC->Log(LOG_INFO, "FileReader::OpenFile() %s.", m_pFileName);
-    void* fileHandle = XBMC->OpenFile(m_pFileName, READ_CHUNKED);
-    if (fileHandle)
+    if (strlen(pszFileName) > MAX_PATH)
+      return ERROR_FILENAME_EXCED_RANGE;
+
+    // Take a copy of the filename
+    if (m_pFileName)
     {
-      m_hFile = fileHandle;
-      break;
+      delete[] m_pFileName;
+      m_pFileName = NULL;
     }
 
-    // Is this still needed on Windows?
-    //CStdStringW strWFile = UTF8Util::ConvertUTF8ToUTF16(m_pFileName);
-    usleep(20000) ;
-  }
-  while(--Tmo);
+    m_pFileName = new char[1 + strlen(pszFileName)];
+    if (m_pFileName == NULL)
+      return E_OUTOFMEMORY;
 
-  if (Tmo)
-  {
-    if (Tmo<4) // 1 failed + 1 succeded is quasi-normal, more is a bit suspicious ( disk drive too slow or problem ? )
-      XBMC->Log(LOG_DEBUG, "FileReader::OpenFile(), %d tries to succeed opening %ws.", 6-Tmo, m_pFileName);
-  }
-  else
-  {
-    XBMC->Log(LOG_ERROR, "FileReader::OpenFile(), open file %s failed.", m_pFileName);
-    return S_FALSE;
-  }
+    strncpy(m_pFileName, pszFileName, strlen(pszFileName) + 1);
 
-  XBMC->Log(LOG_DEBUG, "%s: OpenFile(%s) succeeded.", __FUNCTION__, m_pFileName );
-
-  return S_OK;
-
-} // Open
-
-//
-// CloseFile
-//
-// Closes any dump file we have opened
-//
-long FileReader::CloseFile()
-{
-  if (IsFileInvalid())
-  {
     return S_OK;
   }
 
-  if (m_hFile)
+  //
+  // OpenFile
+  //
+  // Opens the file ready for streaming
+  //
+  long FileReader::OpenFile()
   {
-    XBMC->CloseFile(m_hFile);
-    m_hFile = NULL;
+    int Tmo = 25; //5 in MediaPortal
+
+    // Is the file already opened
+    if (!IsFileInvalid())
+    {
+      XBMC->Log(LOG_NOTICE, "FileReader::OpenFile() file already open");
+      return S_OK;
+    }
+
+    // Has a filename been set yet
+    if (m_pFileName == NULL)
+    {
+      XBMC->Log(LOG_ERROR, "FileReader::OpenFile() no filename");
+      return ERROR_INVALID_NAME;
+    }
+
+    XBMC->Log(LOG_DEBUG, "FileReader::OpenFile() Trying to open %s\n", m_pFileName);
+
+    do
+    {
+      XBMC->Log(LOG_INFO, "FileReader::OpenFile() %s.", m_pFileName);
+      void* fileHandle = XBMC->OpenFile(m_pFileName, READ_CHUNKED);
+      if (fileHandle)
+      {
+        m_hFile = fileHandle;
+        break;
+      }
+
+      // Is this still needed on Windows?
+      //CStdStringW strWFile = UTF8Util::ConvertUTF8ToUTF16(m_pFileName);
+      usleep(20000);
+    } while (--Tmo);
+
+    if (Tmo)
+    {
+      if (Tmo < 4) // 1 failed + 1 succeded is quasi-normal, more is a bit suspicious ( disk drive too slow or problem ? )
+        XBMC->Log(LOG_DEBUG, "FileReader::OpenFile(), %d tries to succeed opening %ws.", 6 - Tmo, m_pFileName);
+    }
+    else
+    {
+      XBMC->Log(LOG_ERROR, "FileReader::OpenFile(), open file %s failed.", m_pFileName);
+      return S_FALSE;
+    }
+
+    XBMC->Log(LOG_DEBUG, "%s: OpenFile(%s) succeeded.", __FUNCTION__, m_pFileName);
+
+    return S_OK;
+
+  } // Open
+
+  //
+  // CloseFile
+  //
+  // Closes any dump file we have opened
+  //
+  long FileReader::CloseFile()
+  {
+    if (IsFileInvalid())
+    {
+      return S_OK;
+    }
+
+    if (m_hFile)
+    {
+      XBMC->CloseFile(m_hFile);
+      m_hFile = NULL;
+    }
+
+    return S_OK;
+  } // CloseFile
+
+
+  inline bool FileReader::IsFileInvalid()
+  {
+    return m_hFile == NULL;
   }
 
-  return S_OK;
-} // CloseFile
-
-
-inline bool FileReader::IsFileInvalid()
-{
-  return m_hFile == NULL;
-}
-
-int64_t FileReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
-{
-  //XBMC->Log(LOG_DEBUG, "%s: distance %d method %d.", __FUNCTION__, llDistanceToMove, dwMoveMethod);
-  int64_t rc = XBMC->SeekFile(m_hFile, llDistanceToMove, dwMoveMethod);
-  //XBMC->Log(LOG_DEBUG, "%s: distance %d method %d returns %d.", __FUNCTION__, llDistanceToMove, dwMoveMethod, rc);
-  return rc;
-}
-
-
-int64_t FileReader::GetFilePointer()
-{
-  return XBMC->GetFilePosition(m_hFile);
-}
-
-
-long FileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
-{
-  *dwReadBytes = XBMC->ReadFile(m_hFile, (void*)pbData, lDataLength);//Read file data into buffer
-  //XBMC->Log(LOG_DEBUG, "%s: requested read length %d actually read %d.", __FUNCTION__, lDataLength, *dwReadBytes);
-
-  if (*dwReadBytes < lDataLength)
+  int64_t FileReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
   {
-    XBMC->Log(LOG_DEBUG, "FileReader::Read() read too less bytes");
-    return S_FALSE;
+    //XBMC->Log(LOG_DEBUG, "%s: distance %d method %d.", __FUNCTION__, llDistanceToMove, dwMoveMethod);
+    int64_t rc = XBMC->SeekFile(m_hFile, llDistanceToMove, dwMoveMethod);
+    //XBMC->Log(LOG_DEBUG, "%s: distance %d method %d returns %d.", __FUNCTION__, llDistanceToMove, dwMoveMethod, rc);
+    return rc;
   }
-  return S_OK;
-}
 
-void FileReader::SetDebugOutput(bool bDebugOutput)
-{
-  m_bDebugOutput = bDebugOutput;
-}
 
-int64_t FileReader::GetFileSize()
-{
-  return XBMC->GetFileLength(m_hFile);
-}
+  int64_t FileReader::GetFilePointer()
+  {
+    return XBMC->GetFilePosition(m_hFile);
+  }
 
-void FileReader::OnZap(void)
-{
-  SetFilePointer(0, FILE_END);
+
+  long FileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+  {
+    *dwReadBytes = XBMC->ReadFile(m_hFile, (void*)pbData, lDataLength);//Read file data into buffer
+    //XBMC->Log(LOG_DEBUG, "%s: requested read length %d actually read %d.", __FUNCTION__, lDataLength, *dwReadBytes);
+
+    if (*dwReadBytes < lDataLength)
+    {
+      XBMC->Log(LOG_DEBUG, "FileReader::Read() read too less bytes");
+      return S_FALSE;
+    }
+    return S_OK;
+  }
+
+  void FileReader::SetDebugOutput(bool bDebugOutput)
+  {
+    m_bDebugOutput = bDebugOutput;
+  }
+
+  int64_t FileReader::GetFileSize()
+  {
+    return XBMC->GetFileLength(m_hFile);
+  }
+
+  void FileReader::OnZap(void)
+  {
+    SetFilePointer(0, FILE_END);
+  }
 }

--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -35,32 +35,35 @@
 
 #include "kodi/os.h"
 
-class FileReader
+namespace ArgusTV
 {
+  class FileReader
+  {
   public:
-    FileReader();
-    virtual ~FileReader();
+      FileReader();
+      virtual ~FileReader();
 
-    // Open and write to the file
-    virtual long GetFileName(char* *lpszFileName);
-    virtual long SetFileName(const char* pszFileName);
-    virtual long OpenFile();
-    virtual long CloseFile();
-    virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
-    virtual bool IsFileInvalid();
-    virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
-    virtual int64_t GetFilePointer();
-    virtual void OnZap(void);
-    virtual int64_t GetFileSize();
-    virtual bool IsBuffer(){return false;};
+      // Open and write to the file
+      virtual long GetFileName(char* *lpszFileName);
+      virtual long SetFileName(const char* pszFileName);
+      virtual long OpenFile();
+      virtual long CloseFile();
+      virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+      virtual bool IsFileInvalid();
+      virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
+      virtual int64_t GetFilePointer();
+      virtual void OnZap(void);
+      virtual int64_t GetFileSize();
+      virtual bool IsBuffer(){ return false; };
 
-    void SetDebugOutput(bool bDebugOutput);
+      void SetDebugOutput(bool bDebugOutput);
 
   protected:
-    void*    m_hFile;               // Handle to file for streaming
-    char*    m_pFileName;           // The filename where we stream
-    int64_t  m_fileSize;
-    int64_t  m_fileStartPos;
+      void*    m_hFile;               // Handle to file for streaming
+      char*    m_pFileName;           // The filename where we stream
+      int64_t  m_fileSize;
+      int64_t  m_fileStartPos;
 
-    bool     m_bDebugOutput;
-};
+      bool     m_bDebugOutput;
+  };
+}

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -54,585 +54,589 @@ using namespace PLATFORM;
 //Maximum time in msec to wait for the buffer file to become available - Needed for DVB radio (this sometimes takes some time)
 #define MAX_BUFFER_TIMEOUT 1500
 
-MultiFileReader::MultiFileReader():
-  m_TSBufferFile(),
-  m_TSFile()
+namespace ArgusTV
 {
-  m_startPosition = 0;
-  m_endPosition = 0;
-  m_currentReadPosition = 0;
-  m_lastZapPosition = 0;
-  m_filesAdded = 0;
-  m_filesRemoved = 0;
-  m_TSFileId = 0;
-  m_bDelay = 0;
-  m_bDebugOutput = false;
-}
 
-MultiFileReader::~MultiFileReader()
-{
-  //CloseFile called by ~FileReader
-}
-
-
-long MultiFileReader::GetFileName(char* *lpszFileName)
-{
-//  CheckPointer(lpszFileName,E_POINTER);
-  return m_TSBufferFile.GetFileName(lpszFileName);
-}
-
-long MultiFileReader::SetFileName(const char* pszFileName)
-{
-  return m_TSBufferFile.SetFileName(pszFileName);
-}
-
-//
-// OpenFile
-//
-long MultiFileReader::OpenFile()
-{
-  char * bufferfilename;
-  m_TSBufferFile.GetFileName(&bufferfilename);
-
-  struct __stat64 stat;
-  if (XBMC->StatFile(bufferfilename, &stat) != 0)
-  {
-	  XBMC->Log(LOG_ERROR, "MultiFileReader: can not get stat from buffer file %s.", bufferfilename);
-	  return S_FALSE;
-  }
-
-  int64_t fileLength = stat.st_size;
-  XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file %s, stat.st_size %ld.", bufferfilename, fileLength);
-
-  int retryCount = 0;
-  if (fileLength == 0) do
-  {
-    retryCount++;
-    XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file has zero length, closing, waiting 500 ms and re-opening. Try %d.", retryCount);
-    usleep(500000);
-    XBMC->StatFile(bufferfilename, &stat);
-    fileLength = stat.st_size;
-  } while (fileLength == 0 && retryCount < 20);
-  XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file %s, after %d retries stat.st_size returns %ld.", bufferfilename, retryCount, fileLength);
-
-  long hr = m_TSBufferFile.OpenFile();
-
-  if (RefreshTSBufferFile() == S_FALSE)
-  {
-    // For radio the buffer sometimes needs some time to become available, so wait and try it more than once
-    PLATFORM::CTimeout timeout(MAX_BUFFER_TIMEOUT);
-
-    do
-    {
-      usleep(100000);
-      if (timeout.TimeLeft() == 0)
-      {
-        XBMC->Log(LOG_ERROR, "MultiFileReader: timed out while waiting for buffer file to become available");
-        XBMC->QueueNotification(QUEUE_ERROR, "Time out while waiting for buffer file");
-        return S_FALSE;
-      }
-    } while (RefreshTSBufferFile() == S_FALSE);
-  }
-
-  m_currentReadPosition = 0;
-
-  return hr;
-}
-
-//
-// CloseFile
-//
-long MultiFileReader::CloseFile()
-{
-  long hr;
-  hr = m_TSBufferFile.CloseFile();
-  hr = m_TSFile.CloseFile();
-  std::vector<MultiFileReaderFile *>::iterator it;
-  for (it = m_tsFiles.begin(); it < m_tsFiles.end(); it++)
-  {
-    delete (*it);
-  }
-  m_TSFileId = 0;
-  return hr;
-}
-
-bool MultiFileReader::IsFileInvalid()
-{
-  return m_TSBufferFile.IsFileInvalid();
-}
-
-int64_t MultiFileReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
-{
-  RefreshTSBufferFile();
-
-  if (dwMoveMethod == FILE_END)
-  {
-    m_currentReadPosition = m_endPosition + llDistanceToMove;
-  }
-  else if (dwMoveMethod == FILE_CURRENT)
-  {
-    m_currentReadPosition += llDistanceToMove;
-  }
-  else // if (dwMoveMethod == FILE_BEGIN)
-  {
-    m_currentReadPosition = m_startPosition + llDistanceToMove;
-  }
-
-  if (m_currentReadPosition < m_startPosition)
-    m_currentReadPosition = m_startPosition;
-
-  if (m_currentReadPosition > m_endPosition) {
-    XBMC->Log(LOG_ERROR, "Seeking beyond the end position: %I64d > %I64d", m_currentReadPosition, m_endPosition);
-    m_currentReadPosition = m_endPosition;
-  }
-
-//  RefreshTSBufferFile();
-  return S_OK;
-}
-
-int64_t MultiFileReader::GetFilePointer()
-{
-//  RefreshTSBufferFile();
-  return m_currentReadPosition;
-}
-
-long MultiFileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
-{
-  long hr;
-
-  // If the file has already been closed, don't continue
-  if (m_TSBufferFile.IsFileInvalid())
-    return S_FALSE;
-
-  RefreshTSBufferFile();
-
-  if (m_currentReadPosition < m_startPosition)
-  {
-    XBMC->Log(LOG_DEBUG, "%s: current position adjusted from %%I64dd to %%I64dd.", __FUNCTION__, m_currentReadPosition, m_startPosition);
-    m_currentReadPosition = m_startPosition;
-  }
-
-  // Find out which file the currentPosition is in.
-  MultiFileReaderFile *file = NULL;
-  std::vector<MultiFileReaderFile *>::iterator it = m_tsFiles.begin();
-  for ( ; it < m_tsFiles.end() ; it++ )
-  {
-    file = *it;
-    if (m_currentReadPosition < (file->startPosition + file->length))
-      break;
-  };
-
-  // XBMC->Log(LOG_DEBUG, "%s: reading %ld bytes. File %s, start %d, current %d, end %d.", __FUNCTION__, lDataLength, file->filename.c_str(), m_startPosition, m_currentPosition, m_endPosition);
-
-
-  if(!file)
-  {
-    XBMC->Log(LOG_ERROR, "MultiFileReader::no file");
-    XBMC->QueueNotification(QUEUE_ERROR, "No buffer file");
-    return S_FALSE;
-  }
-  if (m_currentReadPosition < (file->startPosition + file->length))
-  {
-    if (m_TSFileId != file->filePositionId)
-    {
-      m_TSFile.CloseFile();
-      m_TSFile.SetFileName(file->filename.c_str());
-      m_TSFile.OpenFile();
-
-      m_TSFileId = file->filePositionId;
-
-      if (m_bDebugOutput)
-      {
-        XBMC->Log(LOG_DEBUG, "MultiFileReader::Read() Current File Changed to %s\n", file->filename.c_str());
-      }
-    }
-
-    int64_t seekPosition = m_currentReadPosition - file->startPosition;
-
-    int64_t posSeeked=m_TSFile.GetFilePointer();
-    if (posSeeked != seekPosition)
-    {
-      m_TSFile.SetFilePointer(seekPosition, FILE_BEGIN);
-      posSeeked=m_TSFile.GetFilePointer();
-      if (posSeeked!=seekPosition)
-      {
-        XBMC->Log(LOG_ERROR, "SEEK FAILED");
-      }
-    }
-
-    unsigned long bytesRead = 0;
-
-    int64_t bytesToRead = file->length - seekPosition;
-    if ((int64_t)lDataLength > bytesToRead)
-    {
-      // XBMC->Log(LOG_DEBUG, "%s: datalength %lu bytesToRead %lli.", __FUNCTION__, lDataLength, bytesToRead);
-      hr = m_TSFile.Read(pbData, (unsigned long)bytesToRead, &bytesRead);
-      if (FAILED(hr))
-      {
-        XBMC->Log(LOG_ERROR, "READ FAILED1");
-      }
-      m_currentReadPosition += bytesToRead;
-
-      hr = this->Read(pbData + bytesToRead, lDataLength - (unsigned long)bytesToRead, dwReadBytes);
-      if (FAILED(hr))
-      {
-        XBMC->Log(LOG_ERROR, "READ FAILED2");
-      }
-      *dwReadBytes += bytesRead;
-    }
-    else
-    {
-      hr = m_TSFile.Read(pbData, lDataLength, dwReadBytes);
-      if (FAILED(hr))
-      {
-        XBMC->Log(LOG_ERROR, "READ FAILED3");
-      }
-      m_currentReadPosition += lDataLength;
-    }
-  }
-  else
-  {
-    // The current position is past the end of the last file
-    *dwReadBytes = 0;
-  }
-
-  // XBMC->Log(LOG_DEBUG, "%s: read %lu bytes. start %lli, current %lli, end %lli.", __FUNCTION__, *dwReadBytes, m_startPosition, m_currentPosition, m_endPosition);
-  return S_OK;
-}
-
-
-long MultiFileReader::RefreshTSBufferFile()
-{
-  if (m_TSBufferFile.IsFileInvalid())
-    return S_FALSE;
-
-  unsigned long bytesRead;
-  MultiFileReaderFile *file;
-
-  long result;
-  int64_t currentPosition;
-  int32_t filesAdded, filesRemoved;
-  int32_t filesAdded2, filesRemoved2;
-  long Error = 0;
-  long Loop = 10;
-
-  Wchar_t* pBuffer = NULL;
-  do
-  {
-    Error = 0;
-    currentPosition = -1;
-    filesAdded = -1;
-    filesRemoved = -1;
-    filesAdded2 = -2;
-    filesRemoved2 = -2;
-
-    int64_t fileLength = m_TSBufferFile.GetFileSize();
-
-    // Min file length is Header ( int64_t + int32_t + int32_t ) + filelist ( > 0 ) + Footer ( int32_t + int32_t )
-    if (fileLength <= (int64_t)(sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved) + sizeof(wchar_t) + sizeof(filesAdded2) + sizeof(filesRemoved2)))
-    {
-      if (m_bDebugOutput)
-      {
-        XBMC->Log(LOG_DEBUG, "MultiFileReader::RefreshTSBufferFile() TSBufferFile too short");
-      }
-      return S_FALSE;
-    }
-
-    m_TSBufferFile.SetFilePointer(0, FILE_BEGIN);
-
-    uint32_t readLength = sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved);
-    unsigned char* readBuffer = new unsigned char[readLength];
-
-    result = m_TSBufferFile.Read(readBuffer, readLength, &bytesRead);
-
-    if (!SUCCEEDED(result) || bytesRead!=readLength)
-      Error |= 0x02;
-
-    if (Error == 0)
-    {
-      currentPosition = *((int64_t*)(readBuffer + 0));
-      filesAdded = *((int32_t*)(readBuffer + sizeof(currentPosition)));
-      filesRemoved = *((int32_t*)(readBuffer + sizeof(currentPosition) + sizeof(filesAdded)));
-    }
-
-    delete[] readBuffer;
-
-    // If no files added or removed, break the loop !
-    if ((m_filesAdded == filesAdded) && (m_filesRemoved == filesRemoved)) 
-      break;
-
-    int64_t remainingLength = fileLength - sizeof(currentPosition) - sizeof(filesAdded) - sizeof(filesRemoved) - sizeof(filesAdded2) - sizeof(filesRemoved2);
-
-    // Above 100kb seems stupid and figure out a problem !!!
-    if (remainingLength > 100000)
-      Error |= 0x10;
-  
-    pBuffer = (Wchar_t*) new char[(unsigned int)remainingLength];
-
-    result = m_TSBufferFile.Read((unsigned char*) pBuffer, (uint32_t) remainingLength, &bytesRead);
-    if ( !SUCCEEDED(result) || (int64_t) bytesRead != remainingLength)
-      Error |= 0x20;
-
-    readLength = sizeof(filesAdded) + sizeof(filesRemoved);
-
-    readBuffer = new unsigned char[readLength];
-
-    result = m_TSBufferFile.Read(readBuffer, readLength, &bytesRead);
-
-    if (!SUCCEEDED(result) || bytesRead != readLength) 
-      Error |= 0x40;
-
-    if (Error == 0)
-    {
-      filesAdded2 = *((int32_t*)(readBuffer + 0));
-      filesRemoved2 = *((int32_t*)(readBuffer + sizeof(filesAdded2)));
-    }
-
-    delete[] readBuffer;
-
-    if ((filesAdded2 != filesAdded) || (filesRemoved2 != filesRemoved))
-    {
-      Error |= 0x80;
-
-      XBMC->Log(LOG_ERROR, "MultiFileReader has error 0x%x in Loop %d. Try to clear SMB Cache.", Error, 10-Loop);
-      XBMC->Log(LOG_DEBUG, "%s: filesAdded %d, filesAdded2 %d, filesRemoved %d, filesRemoved2 %d.", __FUNCTION__, filesAdded, filesAdded2, filesRemoved, filesRemoved2);
-
-      // try to clear local / remote SMB file cache. This should happen when we close the filehandle
-      m_TSBufferFile.CloseFile();
-      m_TSBufferFile.OpenFile();
-      usleep(5000);
-    }
-
-    if (Error)
-      delete[] pBuffer;
-
-    Loop--;
-  } while ( Error && Loop ); // If Error is set, try again...until Loop reaches 0.
- 
-  if (Loop < 8)
-  {
-    XBMC->Log(LOG_DEBUG, "MultiFileReader has waited %d times for TSbuffer integrity.", 10-Loop) ;
-
-    if(Error)
-    {
-      XBMC->Log(LOG_ERROR, "MultiFileReader has failed for TSbuffer integrity. Error : %x", Error) ;
-      return E_FAIL ;
-    }
-  }
-
-  if ((m_filesAdded != filesAdded) || (m_filesRemoved != filesRemoved))
-  {
-    long filesToRemove = filesRemoved - m_filesRemoved;
-    long filesToAdd = filesAdded - m_filesAdded;
-    long fileID = filesRemoved;
-    int64_t nextStartPosition = 0;
-
-    if (m_bDebugOutput)
-    {
-      XBMC->Log(LOG_DEBUG, "MultiFileReader: Files Added %i, Removed %i\n", filesToAdd, filesToRemove);
-    }
-
-    // Removed files that aren't present anymore.
-    while ((filesToRemove > 0) && (m_tsFiles.size() > 0))
-    {
-      MultiFileReaderFile *file = m_tsFiles.at(0);
-
-      if (m_bDebugOutput)
-      {
-        XBMC->Log(LOG_DEBUG, "MultiFileReader: Removing file %s\n", file->filename.c_str());
-      }
-      
-      delete file;
-      m_tsFiles.erase(m_tsFiles.begin());
-
-      filesToRemove--;
-    }
-
-
-    // Figure out what the start position of the next new file will be
-    if (m_tsFiles.size() > 0)
-    {
-      file = m_tsFiles.back();
-
-      if (filesToAdd > 0)
-      {
-        // If we're adding files the changes are the one at the back has a partial length
-        // so we need update it.
-        if (m_bDebugOutput)
-          GetFileLength(file->filename.c_str(), file->length);
-        else
-          GetFileLength(file->filename.c_str(), file->length);
-      }
-
-      nextStartPosition = file->startPosition + file->length;
-    }
-
-    // Get the real path of the buffer file
-    char* filename;
-    std::string sFilename;
-    std::string path;
-    size_t pos = std::string::npos;
-
-    m_TSBufferFile.GetFileName(&filename);
-    sFilename = filename;
-    pos = sFilename.find_last_of('/');
-    path = sFilename.substr(0, pos+1);
-    //name3 = filename1.substr(pos+1);
-
-    // Create a list of files in the .tsbuffer file.
-    std::vector<std::string> filenames;
-
-    Wchar_t* pwCurrFile = pBuffer;    //Get a pointer to the first wchar filename string in pBuffer
-    long length = WcsLen(pwCurrFile);
-
-    //XBMC->Log(LOG_DEBUG, "%s: WcsLen(%d), sizeof(wchar_t) == %d.", __FUNCTION__, length, sizeof(wchar_t));
-
-    while(length > 0)
-    {
-      // Convert the current filename (wchar to normal char)
-      char* wide2normal = new char[length + 1];
-      WcsToMbs( wide2normal, pwCurrFile, length);
-      wide2normal[length] = '\0';
-
-      //unsigned char* pb = (unsigned char*) wide2normal;
-      //for (unsigned long i = 0; i < rc; i++)
-      //{
-      //  XBMC->Log(LOG_DEBUG, "%s: pBuffer byte[%d] == %x.", __FUNCTION__, i, pb[i]);
-      //}
-
-      std::string sCurrFile = wide2normal;
-      //XBMC->Log(LOG_DEBUG, "%s: filename %s (%s).", __FUNCTION__, wide2normal, sCurrFile.c_str());
-      delete[] wide2normal;
-
-      // Modify filename path here to include the real (local) path
-      pos = sCurrFile.find_last_of(92);
-      std::string name = sCurrFile.substr(pos+1);
-      if (path.length()>0 && name.length()>0)
-      {
-        // Replace the original path with our local path
-        filenames.push_back(path + name);
-      }
-      else
-      {
-        // Keep existing path
-        filenames.push_back(sCurrFile);
-      }
-      
-      // Move the wchar buffer pointer to the next wchar string
-      pwCurrFile += (length + 1);
-      length = WcsLen(pwCurrFile);
-    }
-
-    // Go through files
-    std::vector<MultiFileReaderFile *>::iterator itFiles = m_tsFiles.begin();
-    //std::vector<char*>::iterator itFilenames = filenames.begin();
-    std::vector<std::string>::iterator itFilenames = filenames.begin();
-
-    while (itFiles < m_tsFiles.end())
-    {
-      file = *itFiles;
-
-      itFiles++;
-      fileID++;
-
-      if (itFilenames < filenames.end())
-      {
-        // TODO: Check that the filenames match. ( Ambass : With buffer integrity check, probably no need to do this !)
-        itFilenames++;
-      }
-      else
-      {
-        XBMC->Log(LOG_DEBUG, "MultiFileReader: Missing files!!\n");
-      }
-    }
-
-    while (itFilenames < filenames.end())
-    {
-      std::string pFilename = *itFilenames;
-
-      if (m_bDebugOutput)
-      {
-        int nextStPos = (int)nextStartPosition;
-        XBMC->Log(LOG_DEBUG, "MultiFileReader: Adding file %s (%i)\n", pFilename.c_str(), nextStPos);
-      }
-
-      file = new MultiFileReaderFile();
-      file->filename = pFilename;
-      file->startPosition = nextStartPosition;
-
-      fileID++;
-      file->filePositionId = fileID;
-
-      GetFileLength(file->filename.c_str(), file->length);
-
-      m_tsFiles.push_back(file);
-
-      nextStartPosition = file->startPosition + file->length;
-
-      itFilenames++;
-    }
-
-    m_filesAdded = filesAdded;
-    m_filesRemoved = filesRemoved;
-
-    delete[] pBuffer;
-  }
-
-  if (m_tsFiles.size() > 0)
-  {
-    file = m_tsFiles.front();
-    m_startPosition = file->startPosition;
-    // Since the buffer file may be re-used when a channel is changed, we
-    // want the start position to reflect the position in the file after the last
-    // channel change, or the real start position, whichever is larger
-    if (m_lastZapPosition > m_startPosition)
-    {
-        m_startPosition = m_lastZapPosition;
-    }
-
-    file = m_tsFiles.back();
-    file->length = currentPosition;
-    m_endPosition = file->startPosition + currentPosition;
-  
-    if (m_bDebugOutput)
-    {
-      int64_t stPos = m_startPosition;
-      int64_t endPos = m_endPosition;
-      int64_t curPos = m_currentReadPosition;
-      XBMC->Log(LOG_DEBUG, "StartPosition %lli, EndPosition %lli, CurrentPosition %lli\n", stPos, endPos, curPos);
-    }
-  }
-  else
+  MultiFileReader::MultiFileReader() :
+    m_TSBufferFile(),
+    m_TSFile()
   {
     m_startPosition = 0;
     m_endPosition = 0;
+    m_currentReadPosition = 0;
+    m_lastZapPosition = 0;
+    m_filesAdded = 0;
+    m_filesRemoved = 0;
+    m_TSFileId = 0;
+    m_bDelay = 0;
+    m_bDebugOutput = false;
   }
 
-  return S_OK;
-}
-
-long MultiFileReader::GetFileLength(const char* pFilename, int64_t &length)
-{
-  length = 0;
-  struct __stat64 stat;
-  if (XBMC->StatFile(pFilename, &stat) != 0)
+  MultiFileReader::~MultiFileReader()
   {
-	  XBMC->Log(LOG_ERROR, "MultiFileReader::GetFileLength: can not get stat from file %s.", pFilename);
-	  return S_FALSE;
+    //CloseFile called by ~FileReader
   }
 
-  length = stat.st_size;
-  return S_OK;
-}
 
-int64_t MultiFileReader::GetFileSize()
-{
-  RefreshTSBufferFile();
-  return m_endPosition - m_startPosition;
-}
+  long MultiFileReader::GetFileName(char* *lpszFileName)
+  {
+    //  CheckPointer(lpszFileName,E_POINTER);
+    return m_TSBufferFile.GetFileName(lpszFileName);
+  }
 
-void MultiFileReader::OnZap(void)
-{
-  SetFilePointer(0, FILE_END);
-  m_lastZapPosition = m_currentReadPosition;
+  long MultiFileReader::SetFileName(const char* pszFileName)
+  {
+    return m_TSBufferFile.SetFileName(pszFileName);
+  }
+
+  //
+  // OpenFile
+  //
+  long MultiFileReader::OpenFile()
+  {
+    char * bufferfilename;
+    m_TSBufferFile.GetFileName(&bufferfilename);
+
+    struct __stat64 stat;
+    if (XBMC->StatFile(bufferfilename, &stat) != 0)
+    {
+      XBMC->Log(LOG_ERROR, "MultiFileReader: can not get stat from buffer file %s.", bufferfilename);
+      return S_FALSE;
+    }
+
+    int64_t fileLength = stat.st_size;
+    XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file %s, stat.st_size %ld.", bufferfilename, fileLength);
+
+    int retryCount = 0;
+    if (fileLength == 0) do
+    {
+      retryCount++;
+      XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file has zero length, closing, waiting 500 ms and re-opening. Try %d.", retryCount);
+      usleep(500000);
+      XBMC->StatFile(bufferfilename, &stat);
+      fileLength = stat.st_size;
+    } while (fileLength == 0 && retryCount < 20);
+    XBMC->Log(LOG_DEBUG, "MultiFileReader: buffer file %s, after %d retries stat.st_size returns %ld.", bufferfilename, retryCount, fileLength);
+
+    long hr = m_TSBufferFile.OpenFile();
+
+    if (RefreshTSBufferFile() == S_FALSE)
+    {
+      // For radio the buffer sometimes needs some time to become available, so wait and try it more than once
+      PLATFORM::CTimeout timeout(MAX_BUFFER_TIMEOUT);
+
+      do
+      {
+        usleep(100000);
+        if (timeout.TimeLeft() == 0)
+        {
+          XBMC->Log(LOG_ERROR, "MultiFileReader: timed out while waiting for buffer file to become available");
+          XBMC->QueueNotification(QUEUE_ERROR, "Time out while waiting for buffer file");
+          return S_FALSE;
+        }
+      } while (RefreshTSBufferFile() == S_FALSE);
+    }
+
+    m_currentReadPosition = 0;
+
+    return hr;
+  }
+
+  //
+  // CloseFile
+  //
+  long MultiFileReader::CloseFile()
+  {
+    long hr;
+    hr = m_TSBufferFile.CloseFile();
+    hr = m_TSFile.CloseFile();
+    std::vector<MultiFileReaderFile *>::iterator it;
+    for (it = m_tsFiles.begin(); it < m_tsFiles.end(); it++)
+    {
+      delete (*it);
+    }
+    m_TSFileId = 0;
+    return hr;
+  }
+
+  bool MultiFileReader::IsFileInvalid()
+  {
+    return m_TSBufferFile.IsFileInvalid();
+  }
+
+  int64_t MultiFileReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
+  {
+    RefreshTSBufferFile();
+
+    if (dwMoveMethod == FILE_END)
+    {
+      m_currentReadPosition = m_endPosition + llDistanceToMove;
+    }
+    else if (dwMoveMethod == FILE_CURRENT)
+    {
+      m_currentReadPosition += llDistanceToMove;
+    }
+    else // if (dwMoveMethod == FILE_BEGIN)
+    {
+      m_currentReadPosition = m_startPosition + llDistanceToMove;
+    }
+
+    if (m_currentReadPosition < m_startPosition)
+      m_currentReadPosition = m_startPosition;
+
+    if (m_currentReadPosition > m_endPosition) {
+      XBMC->Log(LOG_ERROR, "Seeking beyond the end position: %I64d > %I64d", m_currentReadPosition, m_endPosition);
+      m_currentReadPosition = m_endPosition;
+    }
+
+    //  RefreshTSBufferFile();
+    return S_OK;
+  }
+
+  int64_t MultiFileReader::GetFilePointer()
+  {
+    //  RefreshTSBufferFile();
+    return m_currentReadPosition;
+  }
+
+  long MultiFileReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+  {
+    long hr;
+
+    // If the file has already been closed, don't continue
+    if (m_TSBufferFile.IsFileInvalid())
+      return S_FALSE;
+
+    RefreshTSBufferFile();
+
+    if (m_currentReadPosition < m_startPosition)
+    {
+      XBMC->Log(LOG_DEBUG, "%s: current position adjusted from %%I64dd to %%I64dd.", __FUNCTION__, m_currentReadPosition, m_startPosition);
+      m_currentReadPosition = m_startPosition;
+    }
+
+    // Find out which file the currentPosition is in.
+    MultiFileReaderFile *file = NULL;
+    std::vector<MultiFileReaderFile *>::iterator it = m_tsFiles.begin();
+    for (; it < m_tsFiles.end(); it++)
+    {
+      file = *it;
+      if (m_currentReadPosition < (file->startPosition + file->length))
+        break;
+    };
+
+    // XBMC->Log(LOG_DEBUG, "%s: reading %ld bytes. File %s, start %d, current %d, end %d.", __FUNCTION__, lDataLength, file->filename.c_str(), m_startPosition, m_currentPosition, m_endPosition);
+
+
+    if (!file)
+    {
+      XBMC->Log(LOG_ERROR, "MultiFileReader::no file");
+      XBMC->QueueNotification(QUEUE_ERROR, "No buffer file");
+      return S_FALSE;
+    }
+    if (m_currentReadPosition < (file->startPosition + file->length))
+    {
+      if (m_TSFileId != file->filePositionId)
+      {
+        m_TSFile.CloseFile();
+        m_TSFile.SetFileName(file->filename.c_str());
+        m_TSFile.OpenFile();
+
+        m_TSFileId = file->filePositionId;
+
+        if (m_bDebugOutput)
+        {
+          XBMC->Log(LOG_DEBUG, "MultiFileReader::Read() Current File Changed to %s\n", file->filename.c_str());
+        }
+      }
+
+      int64_t seekPosition = m_currentReadPosition - file->startPosition;
+
+      int64_t posSeeked = m_TSFile.GetFilePointer();
+      if (posSeeked != seekPosition)
+      {
+        m_TSFile.SetFilePointer(seekPosition, FILE_BEGIN);
+        posSeeked = m_TSFile.GetFilePointer();
+        if (posSeeked != seekPosition)
+        {
+          XBMC->Log(LOG_ERROR, "SEEK FAILED");
+        }
+      }
+
+      unsigned long bytesRead = 0;
+
+      int64_t bytesToRead = file->length - seekPosition;
+      if ((int64_t)lDataLength > bytesToRead)
+      {
+        // XBMC->Log(LOG_DEBUG, "%s: datalength %lu bytesToRead %lli.", __FUNCTION__, lDataLength, bytesToRead);
+        hr = m_TSFile.Read(pbData, (unsigned long)bytesToRead, &bytesRead);
+        if (FAILED(hr))
+        {
+          XBMC->Log(LOG_ERROR, "READ FAILED1");
+        }
+        m_currentReadPosition += bytesToRead;
+
+        hr = this->Read(pbData + bytesToRead, lDataLength - (unsigned long)bytesToRead, dwReadBytes);
+        if (FAILED(hr))
+        {
+          XBMC->Log(LOG_ERROR, "READ FAILED2");
+        }
+        *dwReadBytes += bytesRead;
+      }
+      else
+      {
+        hr = m_TSFile.Read(pbData, lDataLength, dwReadBytes);
+        if (FAILED(hr))
+        {
+          XBMC->Log(LOG_ERROR, "READ FAILED3");
+        }
+        m_currentReadPosition += lDataLength;
+      }
+    }
+    else
+    {
+      // The current position is past the end of the last file
+      *dwReadBytes = 0;
+    }
+
+    // XBMC->Log(LOG_DEBUG, "%s: read %lu bytes. start %lli, current %lli, end %lli.", __FUNCTION__, *dwReadBytes, m_startPosition, m_currentPosition, m_endPosition);
+    return S_OK;
+  }
+
+
+  long MultiFileReader::RefreshTSBufferFile()
+  {
+    if (m_TSBufferFile.IsFileInvalid())
+      return S_FALSE;
+
+    unsigned long bytesRead;
+    MultiFileReaderFile *file;
+
+    long result;
+    int64_t currentPosition;
+    int32_t filesAdded, filesRemoved;
+    int32_t filesAdded2, filesRemoved2;
+    long Error = 0;
+    long Loop = 10;
+
+    Wchar_t* pBuffer = NULL;
+    do
+    {
+      Error = 0;
+      currentPosition = -1;
+      filesAdded = -1;
+      filesRemoved = -1;
+      filesAdded2 = -2;
+      filesRemoved2 = -2;
+
+      int64_t fileLength = m_TSBufferFile.GetFileSize();
+
+      // Min file length is Header ( int64_t + int32_t + int32_t ) + filelist ( > 0 ) + Footer ( int32_t + int32_t )
+      if (fileLength <= (int64_t)(sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved) + sizeof(wchar_t) + sizeof(filesAdded2) + sizeof(filesRemoved2)))
+      {
+        if (m_bDebugOutput)
+        {
+          XBMC->Log(LOG_DEBUG, "MultiFileReader::RefreshTSBufferFile() TSBufferFile too short");
+        }
+        return S_FALSE;
+      }
+
+      m_TSBufferFile.SetFilePointer(0, FILE_BEGIN);
+
+      uint32_t readLength = sizeof(currentPosition) + sizeof(filesAdded) + sizeof(filesRemoved);
+      unsigned char* readBuffer = new unsigned char[readLength];
+
+      result = m_TSBufferFile.Read(readBuffer, readLength, &bytesRead);
+
+      if (!SUCCEEDED(result) || bytesRead != readLength)
+        Error |= 0x02;
+
+      if (Error == 0)
+      {
+        currentPosition = *((int64_t*)(readBuffer + 0));
+        filesAdded = *((int32_t*)(readBuffer + sizeof(currentPosition)));
+        filesRemoved = *((int32_t*)(readBuffer + sizeof(currentPosition) + sizeof(filesAdded)));
+      }
+
+      delete[] readBuffer;
+
+      // If no files added or removed, break the loop !
+      if ((m_filesAdded == filesAdded) && (m_filesRemoved == filesRemoved))
+        break;
+
+      int64_t remainingLength = fileLength - sizeof(currentPosition) - sizeof(filesAdded) - sizeof(filesRemoved) - sizeof(filesAdded2) - sizeof(filesRemoved2);
+
+      // Above 100kb seems stupid and figure out a problem !!!
+      if (remainingLength > 100000)
+        Error |= 0x10;
+
+      pBuffer = (Wchar_t*) new char[(unsigned int)remainingLength];
+
+      result = m_TSBufferFile.Read((unsigned char*)pBuffer, (uint32_t)remainingLength, &bytesRead);
+      if (!SUCCEEDED(result) || (int64_t)bytesRead != remainingLength)
+        Error |= 0x20;
+
+      readLength = sizeof(filesAdded) + sizeof(filesRemoved);
+
+      readBuffer = new unsigned char[readLength];
+
+      result = m_TSBufferFile.Read(readBuffer, readLength, &bytesRead);
+
+      if (!SUCCEEDED(result) || bytesRead != readLength)
+        Error |= 0x40;
+
+      if (Error == 0)
+      {
+        filesAdded2 = *((int32_t*)(readBuffer + 0));
+        filesRemoved2 = *((int32_t*)(readBuffer + sizeof(filesAdded2)));
+      }
+
+      delete[] readBuffer;
+
+      if ((filesAdded2 != filesAdded) || (filesRemoved2 != filesRemoved))
+      {
+        Error |= 0x80;
+
+        XBMC->Log(LOG_ERROR, "MultiFileReader has error 0x%x in Loop %d. Try to clear SMB Cache.", Error, 10 - Loop);
+        XBMC->Log(LOG_DEBUG, "%s: filesAdded %d, filesAdded2 %d, filesRemoved %d, filesRemoved2 %d.", __FUNCTION__, filesAdded, filesAdded2, filesRemoved, filesRemoved2);
+
+        // try to clear local / remote SMB file cache. This should happen when we close the filehandle
+        m_TSBufferFile.CloseFile();
+        m_TSBufferFile.OpenFile();
+        usleep(5000);
+      }
+
+      if (Error)
+        delete[] pBuffer;
+
+      Loop--;
+    } while (Error && Loop); // If Error is set, try again...until Loop reaches 0.
+
+    if (Loop < 8)
+    {
+      XBMC->Log(LOG_DEBUG, "MultiFileReader has waited %d times for TSbuffer integrity.", 10 - Loop);
+
+      if (Error)
+      {
+        XBMC->Log(LOG_ERROR, "MultiFileReader has failed for TSbuffer integrity. Error : %x", Error);
+        return E_FAIL;
+      }
+    }
+
+    if ((m_filesAdded != filesAdded) || (m_filesRemoved != filesRemoved))
+    {
+      long filesToRemove = filesRemoved - m_filesRemoved;
+      long filesToAdd = filesAdded - m_filesAdded;
+      long fileID = filesRemoved;
+      int64_t nextStartPosition = 0;
+
+      if (m_bDebugOutput)
+      {
+        XBMC->Log(LOG_DEBUG, "MultiFileReader: Files Added %i, Removed %i\n", filesToAdd, filesToRemove);
+      }
+
+      // Removed files that aren't present anymore.
+      while ((filesToRemove > 0) && (m_tsFiles.size() > 0))
+      {
+        MultiFileReaderFile *file = m_tsFiles.at(0);
+
+        if (m_bDebugOutput)
+        {
+          XBMC->Log(LOG_DEBUG, "MultiFileReader: Removing file %s\n", file->filename.c_str());
+        }
+
+        delete file;
+        m_tsFiles.erase(m_tsFiles.begin());
+
+        filesToRemove--;
+      }
+
+
+      // Figure out what the start position of the next new file will be
+      if (m_tsFiles.size() > 0)
+      {
+        file = m_tsFiles.back();
+
+        if (filesToAdd > 0)
+        {
+          // If we're adding files the changes are the one at the back has a partial length
+          // so we need update it.
+          if (m_bDebugOutput)
+            GetFileLength(file->filename.c_str(), file->length);
+          else
+            GetFileLength(file->filename.c_str(), file->length);
+        }
+
+        nextStartPosition = file->startPosition + file->length;
+      }
+
+      // Get the real path of the buffer file
+      char* filename;
+      std::string sFilename;
+      std::string path;
+      size_t pos = std::string::npos;
+
+      m_TSBufferFile.GetFileName(&filename);
+      sFilename = filename;
+      pos = sFilename.find_last_of('/');
+      path = sFilename.substr(0, pos + 1);
+      //name3 = filename1.substr(pos+1);
+
+      // Create a list of files in the .tsbuffer file.
+      std::vector<std::string> filenames;
+
+      Wchar_t* pwCurrFile = pBuffer;    //Get a pointer to the first wchar filename string in pBuffer
+      long length = WcsLen(pwCurrFile);
+
+      //XBMC->Log(LOG_DEBUG, "%s: WcsLen(%d), sizeof(wchar_t) == %d.", __FUNCTION__, length, sizeof(wchar_t));
+
+      while (length > 0)
+      {
+        // Convert the current filename (wchar to normal char)
+        char* wide2normal = new char[length + 1];
+        WcsToMbs(wide2normal, pwCurrFile, length);
+        wide2normal[length] = '\0';
+
+        //unsigned char* pb = (unsigned char*) wide2normal;
+        //for (unsigned long i = 0; i < rc; i++)
+        //{
+        //  XBMC->Log(LOG_DEBUG, "%s: pBuffer byte[%d] == %x.", __FUNCTION__, i, pb[i]);
+        //}
+
+        std::string sCurrFile = wide2normal;
+        //XBMC->Log(LOG_DEBUG, "%s: filename %s (%s).", __FUNCTION__, wide2normal, sCurrFile.c_str());
+        delete[] wide2normal;
+
+        // Modify filename path here to include the real (local) path
+        pos = sCurrFile.find_last_of(92);
+        std::string name = sCurrFile.substr(pos + 1);
+        if (path.length() > 0 && name.length() > 0)
+        {
+          // Replace the original path with our local path
+          filenames.push_back(path + name);
+        }
+        else
+        {
+          // Keep existing path
+          filenames.push_back(sCurrFile);
+        }
+
+        // Move the wchar buffer pointer to the next wchar string
+        pwCurrFile += (length + 1);
+        length = WcsLen(pwCurrFile);
+      }
+
+      // Go through files
+      std::vector<MultiFileReaderFile *>::iterator itFiles = m_tsFiles.begin();
+      //std::vector<char*>::iterator itFilenames = filenames.begin();
+      std::vector<std::string>::iterator itFilenames = filenames.begin();
+
+      while (itFiles < m_tsFiles.end())
+      {
+        file = *itFiles;
+
+        itFiles++;
+        fileID++;
+
+        if (itFilenames < filenames.end())
+        {
+          // TODO: Check that the filenames match. ( Ambass : With buffer integrity check, probably no need to do this !)
+          itFilenames++;
+        }
+        else
+        {
+          XBMC->Log(LOG_DEBUG, "MultiFileReader: Missing files!!\n");
+        }
+      }
+
+      while (itFilenames < filenames.end())
+      {
+        std::string pFilename = *itFilenames;
+
+        if (m_bDebugOutput)
+        {
+          int nextStPos = (int)nextStartPosition;
+          XBMC->Log(LOG_DEBUG, "MultiFileReader: Adding file %s (%i)\n", pFilename.c_str(), nextStPos);
+        }
+
+        file = new MultiFileReaderFile();
+        file->filename = pFilename;
+        file->startPosition = nextStartPosition;
+
+        fileID++;
+        file->filePositionId = fileID;
+
+        GetFileLength(file->filename.c_str(), file->length);
+
+        m_tsFiles.push_back(file);
+
+        nextStartPosition = file->startPosition + file->length;
+
+        itFilenames++;
+      }
+
+      m_filesAdded = filesAdded;
+      m_filesRemoved = filesRemoved;
+
+      delete[] pBuffer;
+    }
+
+    if (m_tsFiles.size() > 0)
+    {
+      file = m_tsFiles.front();
+      m_startPosition = file->startPosition;
+      // Since the buffer file may be re-used when a channel is changed, we
+      // want the start position to reflect the position in the file after the last
+      // channel change, or the real start position, whichever is larger
+      if (m_lastZapPosition > m_startPosition)
+      {
+        m_startPosition = m_lastZapPosition;
+      }
+
+      file = m_tsFiles.back();
+      file->length = currentPosition;
+      m_endPosition = file->startPosition + currentPosition;
+
+      if (m_bDebugOutput)
+      {
+        int64_t stPos = m_startPosition;
+        int64_t endPos = m_endPosition;
+        int64_t curPos = m_currentReadPosition;
+        XBMC->Log(LOG_DEBUG, "StartPosition %lli, EndPosition %lli, CurrentPosition %lli\n", stPos, endPos, curPos);
+      }
+    }
+    else
+    {
+      m_startPosition = 0;
+      m_endPosition = 0;
+    }
+
+    return S_OK;
+  }
+
+  long MultiFileReader::GetFileLength(const char* pFilename, int64_t &length)
+  {
+    length = 0;
+    struct __stat64 stat;
+    if (XBMC->StatFile(pFilename, &stat) != 0)
+    {
+      XBMC->Log(LOG_ERROR, "MultiFileReader::GetFileLength: can not get stat from file %s.", pFilename);
+      return S_FALSE;
+    }
+
+    length = stat.st_size;
+    return S_OK;
+  }
+
+  int64_t MultiFileReader::GetFileSize()
+  {
+    RefreshTSBufferFile();
+    return m_endPosition - m_startPosition;
+  }
+
+  void MultiFileReader::OnZap(void)
+  {
+    SetFilePointer(0, FILE_END);
+    m_lastZapPosition = m_currentReadPosition;
+  }
 }

--- a/src/lib/tsreader/MultiFileReader.h
+++ b/src/lib/tsreader/MultiFileReader.h
@@ -37,49 +37,52 @@
 #include <vector>
 #include <string>
 
-class MultiFileReaderFile
+namespace ArgusTV
 {
+  class MultiFileReaderFile
+  {
   public:
-    std::string filename;
-    int64_t startPosition;
-    int64_t length;
-    long filePositionId;
-};
+      std::string filename;
+      int64_t startPosition;
+      int64_t length;
+      long filePositionId;
+  };
 
-class MultiFileReader : public FileReader
-{
+  class MultiFileReader : public FileReader
+  {
   public:
-    MultiFileReader();
-    virtual ~MultiFileReader();
+      MultiFileReader();
+      virtual ~MultiFileReader();
 
-    virtual long GetFileName(char* *lpszFileName);
-    virtual long SetFileName(const char* pszFileName);
-    virtual long OpenFile();
-    virtual long CloseFile();
-    virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
-    virtual bool IsFileInvalid();
+      virtual long GetFileName(char* *lpszFileName);
+      virtual long SetFileName(const char* pszFileName);
+      virtual long OpenFile();
+      virtual long CloseFile();
+      virtual long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+      virtual bool IsFileInvalid();
 
-    virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
-    virtual int64_t GetFilePointer();
-    virtual int64_t GetFileSize();
-    virtual void OnZap(void);
+      virtual int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
+      virtual int64_t GetFilePointer();
+      virtual int64_t GetFileSize();
+      virtual void OnZap(void);
 
   protected:
-    long RefreshTSBufferFile();
-    long GetFileLength(const char* pFilename, int64_t &length);
+      long RefreshTSBufferFile();
+      long GetFileLength(const char* pFilename, int64_t &length);
 
-    FileReader m_TSBufferFile;
-    int64_t m_startPosition;
-    int64_t m_endPosition;
-    int64_t m_currentReadPosition;
-    long m_filesAdded;
-    long m_filesRemoved;
-    int64_t m_lastZapPosition;
+      FileReader m_TSBufferFile;
+      int64_t m_startPosition;
+      int64_t m_endPosition;
+      int64_t m_currentReadPosition;
+      long m_filesAdded;
+      long m_filesRemoved;
+      int64_t m_lastZapPosition;
 
-    std::vector<MultiFileReaderFile *> m_tsFiles;
+      std::vector<MultiFileReaderFile *> m_tsFiles;
 
-    FileReader m_TSFile;
-    long     m_TSFileId;
-    bool     m_bDelay;
-    bool     m_bDebugOutput;
-};
+      FileReader m_TSFile;
+      long     m_TSFileId;
+      bool     m_bDelay;
+      bool     m_bDebugOutput;
+  };
+}

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -35,131 +35,134 @@
 
 using namespace ADDON;
 
-CTsReader::CTsReader()
+namespace ArgusTV
 {
-  m_fileReader=NULL;
-  m_bLiveTv = false;
-  m_bTimeShifting = false;
-#if defined(TARGET_WINDOWS)
-  liDelta.QuadPart = liCount.QuadPart = 0;
-#endif
-}
-
-long CTsReader::Open(const char* pszFileName)
-{
-  XBMC->Log(LOG_DEBUG, "CTsReader::Open(%s)", pszFileName);
-
-  m_fileName = pszFileName;
-  char url[MAX_PATH];
-  strncpy(url, m_fileName.c_str(), MAX_PATH-1);
-  url[MAX_PATH-1]='\0'; // make sure that we always have a 0-terminated string
-
-  //check file type
-  int length = strlen(url);
-
-  if ((length < 9) || (strnicmp(&url[length-9], ".tsbuffer", 9) != 0))
+  CTsReader::CTsReader()
   {
-    //local .ts file
-    m_bTimeShifting = false;
+    m_fileReader = NULL;
     m_bLiveTv = false;
-    m_fileReader = new FileReader();
-  }
-  else
-  {
-    //local timeshift buffer file file
-    m_bTimeShifting = true;
-    m_bLiveTv = true;
-    m_fileReader = new MultiFileReader();
-  }
-
-  //open file
-  if (m_fileReader->SetFileName(m_fileName.c_str()) != S_OK)
-  {
-    XBMC->Log(LOG_ERROR, "CTsReader::SetFileName failed.");
-    return S_FALSE;
-  }
-  if (m_fileReader->OpenFile() != S_OK)
-  {
-    XBMC->Log(LOG_ERROR, "CTsReader::OpenFile failed.");
-    return S_FALSE;
-  }
-  m_fileReader->SetFilePointer(0LL, FILE_BEGIN);
-
-  return S_OK;
-}
-
-long CTsReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
-{
+    m_bTimeShifting = false;
 #if defined(TARGET_WINDOWS)
-  LARGE_INTEGER liFrequency;
-  LARGE_INTEGER liCurrent;
-  LARGE_INTEGER liLast;
+    liDelta.QuadPart = liCount.QuadPart = 0;
 #endif
-  if(m_fileReader)
-  {
-#if defined(TARGET_WINDOWS)
-    // Save the performance counter frequency for later use.
-    if (!QueryPerformanceFrequency(&liFrequency))
-      XBMC->Log(LOG_ERROR, "QPF() failed with error %d\n", GetLastError());
-
-    if (!QueryPerformanceCounter(&liCurrent))
-		  XBMC->Log(LOG_ERROR, "QPC() failed with error %d\n", GetLastError());
-    liLast = liCurrent;
-#endif
-
-    long rc = m_fileReader->Read(pbData, lDataLength, dwReadBytes);
-
-#if defined(TARGET_WINDOWS)
-    if (!QueryPerformanceCounter(&liCurrent))
-      XBMC->Log(LOG_ERROR, "QPC() failed with error %d\n", GetLastError());
-    
-    // Convert difference in performance counter values to nanoseconds.
-    liDelta.QuadPart += (((liCurrent.QuadPart - liLast.QuadPart) * 1000000) / liFrequency.QuadPart);
-    liCount.QuadPart++;
-#endif
-    return rc;
   }
 
-  dwReadBytes = 0;
-  return 1;
-}
-
-void CTsReader::Close()
-{
-  if(m_fileReader)
+  long CTsReader::Open(const char* pszFileName)
   {
-    m_fileReader->CloseFile();
-    SAFE_DELETE(m_fileReader);
+    XBMC->Log(LOG_DEBUG, "CTsReader::Open(%s)", pszFileName);
+
+    m_fileName = pszFileName;
+    char url[MAX_PATH];
+    strncpy(url, m_fileName.c_str(), MAX_PATH - 1);
+    url[MAX_PATH - 1] = '\0'; // make sure that we always have a 0-terminated string
+
+    //check file type
+    int length = strlen(url);
+
+    if ((length < 9) || (strnicmp(&url[length - 9], ".tsbuffer", 9) != 0))
+    {
+      //local .ts file
+      m_bTimeShifting = false;
+      m_bLiveTv = false;
+      m_fileReader = new FileReader();
+    }
+    else
+    {
+      //local timeshift buffer file file
+      m_bTimeShifting = true;
+      m_bLiveTv = true;
+      m_fileReader = new MultiFileReader();
+    }
+
+    //open file
+    if (m_fileReader->SetFileName(m_fileName.c_str()) != S_OK)
+    {
+      XBMC->Log(LOG_ERROR, "CTsReader::SetFileName failed.");
+      return S_FALSE;
+    }
+    if (m_fileReader->OpenFile() != S_OK)
+    {
+      XBMC->Log(LOG_ERROR, "CTsReader::OpenFile failed.");
+      return S_FALSE;
+    }
+    m_fileReader->SetFilePointer(0LL, FILE_BEGIN);
+
+    return S_OK;
   }
-}
 
-int64_t CTsReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
-{
-  return m_fileReader->SetFilePointer(llDistanceToMove, dwMoveMethod);
-}
+  long CTsReader::Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes)
+  {
+#if defined(TARGET_WINDOWS)
+    LARGE_INTEGER liFrequency;
+    LARGE_INTEGER liCurrent;
+    LARGE_INTEGER liLast;
+#endif
+    if (m_fileReader)
+    {
+#if defined(TARGET_WINDOWS)
+      // Save the performance counter frequency for later use.
+      if (!QueryPerformanceFrequency(&liFrequency))
+        XBMC->Log(LOG_ERROR, "QPF() failed with error %d\n", GetLastError());
 
-int64_t CTsReader::GetFileSize()
-{
-  return m_fileReader->GetFileSize();
-}
+      if (!QueryPerformanceCounter(&liCurrent))
+        XBMC->Log(LOG_ERROR, "QPC() failed with error %d\n", GetLastError());
+      liLast = liCurrent;
+#endif
 
-int64_t CTsReader::GetFilePointer()
-{
-  return m_fileReader->GetFilePointer();
-}
-
-void CTsReader::OnZap(void)
-{
-  m_fileReader->OnZap();
-}
+      long rc = m_fileReader->Read(pbData, lDataLength, dwReadBytes);
 
 #if defined(TARGET_WINDOWS)
-long long CTsReader::sigmaTime()
-{
-  return liDelta.QuadPart;
-}
-long long CTsReader::sigmaCount()
-{
-  return liCount.QuadPart;
-}
+      if (!QueryPerformanceCounter(&liCurrent))
+        XBMC->Log(LOG_ERROR, "QPC() failed with error %d\n", GetLastError());
+
+      // Convert difference in performance counter values to nanoseconds.
+      liDelta.QuadPart += (((liCurrent.QuadPart - liLast.QuadPart) * 1000000) / liFrequency.QuadPart);
+      liCount.QuadPart++;
 #endif
+      return rc;
+    }
+
+    dwReadBytes = 0;
+    return 1;
+  }
+
+  void CTsReader::Close()
+  {
+    if (m_fileReader)
+    {
+      m_fileReader->CloseFile();
+      SAFE_DELETE(m_fileReader);
+    }
+  }
+
+  int64_t CTsReader::SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod)
+  {
+    return m_fileReader->SetFilePointer(llDistanceToMove, dwMoveMethod);
+  }
+
+  int64_t CTsReader::GetFileSize()
+  {
+    return m_fileReader->GetFileSize();
+  }
+
+  int64_t CTsReader::GetFilePointer()
+  {
+    return m_fileReader->GetFilePointer();
+  }
+
+  void CTsReader::OnZap(void)
+  {
+    m_fileReader->OnZap();
+  }
+
+#if defined(TARGET_WINDOWS)
+  long long CTsReader::sigmaTime()
+  {
+    return liDelta.QuadPart;
+  }
+  long long CTsReader::sigmaCount()
+  {
+    return liCount.QuadPart;
+  }
+#endif
+}

--- a/src/lib/tsreader/TSReader.h
+++ b/src/lib/tsreader/TSReader.h
@@ -32,31 +32,34 @@
 #include "FileReader.h"
 #include "kodi/util/StdString.h"
 
-class CTsReader
+namespace ArgusTV
 {
-public:
-  CTsReader();
-  ~CTsReader(void) {};
-  long Open(const char* pszFileName);
-  long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
-  void Close();
-  int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
-  int64_t GetFileSize();
-  int64_t GetFilePointer();
-  void OnZap(void);
+  class CTsReader
+  {
+  public:
+    CTsReader();
+    ~CTsReader(void) {};
+    long Open(const char* pszFileName);
+    long Read(unsigned char* pbData, unsigned long lDataLength, unsigned long *dwReadBytes);
+    void Close();
+    int64_t SetFilePointer(int64_t llDistanceToMove, unsigned long dwMoveMethod);
+    int64_t GetFileSize();
+    int64_t GetFilePointer();
+    void OnZap(void);
 #if defined(TARGET_WINDOWS)
-  long long sigmaTime();
-  long long  sigmaCount();
+    long long sigmaTime();
+    long long  sigmaCount();
 #endif
 
-private:
-  bool            m_bTimeShifting;
-  bool            m_bRecording;
-  bool            m_bLiveTv;
-  CStdString      m_fileName;
-  FileReader*     m_fileReader;
+  private:
+    bool            m_bTimeShifting;
+    bool            m_bRecording;
+    bool            m_bLiveTv;
+    CStdString      m_fileName;
+    FileReader*     m_fileReader;
 #if defined(TARGET_WINDOWS)
-  LARGE_INTEGER   liDelta; 
-  LARGE_INTEGER   liCount; 
+    LARGE_INTEGER   liDelta;
+    LARGE_INTEGER   liCount;
 #endif
-};
+  };
+}

--- a/src/lib/tsreader/readme.txt
+++ b/src/lib/tsreader/readme.txt
@@ -1,3 +1,0 @@
-The ARGUS TV pvr client shares the TSReader code with the MediaPortal pvr clients.
-You can find the code here;
-xbmc\pvrclients\MediaPortal\lib\tsreader

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -38,6 +38,7 @@ using namespace std;
 using namespace ADDON;
 
 using namespace PLATFORM;
+using namespace ArgusTV;
 
 #define SIGNALQUALITY_INTERVAL 10
 #define MAXLIFETIME 99 //Based on VDR addon and VDR documentation. 99=Keep forever, 0=can be deleted at any time, 1..98=days to keep

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -31,7 +31,10 @@
 #include "KeepAliveThread.h"
 #include "EventsThread.h"
 
-class CTsReader;
+namespace ArgusTV
+{
+  class CTsReader;
+}
 
 #undef ATV_DUMPTS
 
@@ -127,7 +130,7 @@ private:
   std::vector<cChannel*>   m_RadioChannels; // Local Radio channel cache list needed for id to guid conversion
   int                     m_epg_id_offset;
   int                     m_signalqualityInterval;
-  CTsReader*              m_tsreader;
+  ArgusTV::CTsReader*     m_tsreader;
   CKeepAliveThread*       m_keepalive;
   CEventsThread*          m_eventmonitor;
 #if defined(ATV_DUMPTS)


### PR DESCRIPTION
Fix a crash seen on the Raspberry Pi (caused by xbmc/xbmc#6306).
PR 6306 introduced a 2nd FileReader class in Kodi which conflicts with the PVR addon one...
The PVR FileReader class is now inside a ArgusTV namespace.

This PR is based on kodi-pvr/pvr.mediaportal.tvserver#2.