### PR TITLE
Fix race condition on channel GUID cache

### DIFF
--- a/pvr.argustv/addon.xml
+++ b/pvr.argustv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.10.4"
+  version="1.10.5"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,5 @@
+v1.10.5 (09-04-2015)
+- Fix race condition on Channel GUID cache
 v1.10.4 (28-03-2015)
 - Updated to PVR API v1.9.6
 v1.10.3 (14-03-2015)

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -425,6 +425,7 @@ int cPVRClientArgusTV::GetNumChannels()
 
 PVR_ERROR cPVRClientArgusTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
+  CLockObject lock(m_ChannelCacheMutex);
   Json::Value response;
   int retval = -1;
 
@@ -1122,6 +1123,7 @@ PVR_ERROR cPVRClientArgusTV::UpdateTimer(const PVR_TIMER &timerinfo)
 /** Live stream handling */
 cChannel* cPVRClientArgusTV::FetchChannel(int channelid, bool LogError)
 {
+  CLockObject lock(m_ChannelCacheMutex);
   cChannel* rc = FetchChannel(m_TVChannels, channelid, false);
   if (rc == NULL) rc = FetchChannel(m_RadioChannels, channelid, false);
 

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -126,6 +126,7 @@ private:
   time_t                  m_BackendUTCoffset;
   time_t                  m_BackendTime;
 
+  PLATFORM::CMutex        m_ChannelCacheMutex;
   std::vector<cChannel*>   m_TVChannels; // Local TV channel cache list needed for id to guid conversion
   std::vector<cChannel*>   m_RadioChannels; // Local Radio channel cache list needed for id to guid conversion
   int                     m_epg_id_offset;


### PR DESCRIPTION
Use mutex to fix concurrent threads accessing and clearing the channel GUID cache at the same time,
this fixes an issue when resuming from standby (discovered on OpenElec kodi)

This PR replaces PR #452 to the original opdenkamp repo (https://github.com/opdenkamp/xbmc-pvr-addons/pull/452).