### PR TITLE
Resubmit changes for new group all recordings into folders

### DIFF
--- a/pvr.argustv/addon.xml
+++ b/pvr.argustv/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.10.5"
+  version="1.10.6"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,5 @@
+v1.10.6 (11-04-2015)
+- Added option for all recordings to be in folders 
 v1.10.5 (09-04-2015)
 - Fix race condition on Channel GUID cache
 v1.10.4 (28-03-2015)

--- a/pvr.argustv/resources/language/English/strings.po
+++ b/pvr.argustv/resources/language/English/strings.po
@@ -45,3 +45,7 @@ msgstr ""
 msgctxt "#30006"
 msgid "Delay after tuning (ms)"
 msgstr ""
+
+msgctxt "#30007"
+msgid "Single recordings in folder"
+msgstr ""

--- a/pvr.argustv/resources/settings.xml
+++ b/pvr.argustv/resources/settings.xml
@@ -7,4 +7,5 @@
     <setting id="user" type="text" label="30004" default="Guest" />
     <setting id="pass" type="text" label="30005" option="hidden" default="" />
     <setting id="tunedelay" type="number" label="30006" default="200" />
+    <setting id="usefolder" type="bool" label="30007" default="false" />
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -34,6 +34,7 @@ std::string g_szHostname           = DEFAULT_HOST;         ///< The Host name or
 int         g_iPort                = DEFAULT_PORT;         ///< The TVServerXBMC listening port (default: 49943)
 int         g_iConnectTimeout      = DEFAULT_TIMEOUT;      ///< The Socket connection timeout
 bool        g_bRadioEnabled        = DEFAULT_RADIO;        ///< Send also Radio channels list to XBMC
+bool        g_bUseFolder		   = DEFAULT_USEFOLDER;    ///< Use folders for single recordings
                                                            ///< ARGUS TV uses shares to communicate with clients 
 std::string g_szUser               = DEFAULT_USER;         ///< Windows user account used to access share
 std::string g_szPass               = DEFAULT_PASS;         ///< Windows user password used to access share
@@ -155,6 +156,14 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     g_iTuneDelay = DEFAULT_TUNEDELAY;
   }
 
+  /* Read setting "usefolder" from settings.xml */
+  if (!XBMC->GetSetting("usefolder", &g_bUseFolder))
+  {
+	  /* If setting is unknown fallback to defaults */
+	  XBMC->Log(LOG_ERROR, "Couldn't get 'usefolder' setting, falling back to 'false' as default");
+	  g_bUseFolder = DEFAULT_USEFOLDER;
+  }
+
   /* Connect to ARGUS TV */
   if (!g_client->Connect())
   {
@@ -271,6 +280,11 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   {
     XBMC->Log(LOG_INFO, "Changed setting 'tunedelay' from %u to %u", g_iTuneDelay, *(int*) settingValue);
     g_iTuneDelay = *(int*) settingValue;
+  }
+  else if (str == "usefolder")
+  {
+    XBMC->Log(LOG_INFO, "Changed setting 'usefolder' from %u to %u", g_bUseFolder, *(bool*)settingValue);
+    g_bUseFolder = *(bool*)settingValue;
   }
 
   return ADDON_STATUS_OK;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -159,9 +159,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   /* Read setting "usefolder" from settings.xml */
   if (!XBMC->GetSetting("usefolder", &g_bUseFolder))
   {
-	  /* If setting is unknown fallback to defaults */
-	  XBMC->Log(LOG_ERROR, "Couldn't get 'usefolder' setting, falling back to 'false' as default");
-	  g_bUseFolder = DEFAULT_USEFOLDER;
+    /* If setting is unknown fallback to defaults */
+	XBMC->Log(LOG_ERROR, "Couldn't get 'usefolder' setting, falling back to 'false' as default");
+	g_bUseFolder = DEFAULT_USEFOLDER;
   }
 
   /* Connect to ARGUS TV */

--- a/src/client.h
+++ b/src/client.h
@@ -34,6 +34,7 @@
 #define DEFAULT_USER                  "Guest"
 #define DEFAULT_PASS                  ""
 #define DEFAULT_TUNEDELAY             200
+#define DEFAULT_USEFOLDER		      false
 
 extern bool         g_bCreated;           ///< Shows that the Create function was successfully called
 extern std::string  g_szUserPath;         ///< The Path to the user directory inside user profile
@@ -47,6 +48,7 @@ extern bool         g_bRadioEnabled;
 extern std::string  g_szUser;
 extern std::string  g_szPass;
 extern int          g_iTuneDelay;
+extern bool         g_bUseFolder;
 
 extern std::string  g_szBaseURL;
 

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -699,7 +699,7 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(ADDON_HANDLE handle)
               strncpy(tag.strPlot, recording.Description(), sizeof(tag.strPlot));
               tag.iPlayCount     = recording.FullyWatchedCount();
               tag.iLastPlayedPosition = recording.LastWatchedPosition();
-              if (nrOfRecordings > 1)
+              if (nrOfRecordings > 1 || g_bUseFolder)
               {
                 recording.Transform(true);
                 strncpy(tag.strDirectory, recordinggroup.ProgramTitle().c_str(), sizeof(tag.strDirectory)); //used in XBMC as directory structure below "Server X - hostname"


### PR DESCRIPTION
New pull request for just this feature:  Make it an option to not allow single recordings in the reocrdings view.  All recordings will be grouped into a series folder.  The default is false however to preserve existing functionality.