### PR TITLE
Bump add-on for PVR API 3.0.0 (Compatibility mode)

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.11.3"
+  version="1.11.4"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="2.1.0"/>
+    <import addon="xbmc.pvr" version="3.0.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,5 @@
+v1.11.4 (04-08-2015)
+- Updated to PVR API v3.0.0 (API 1.9.7 compatibility mode)
 v1.11.3 (19-07-2015)
 - Updated to PVR API v2.1.0
 - Automatically fill in platform and library name


### PR DESCRIPTION
Addon part of xbmc/xbmc#7626
Add on currently using 1.9.7 API compatibility code
No further changes required for minimal support