### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.11.5"
+  version="1.11.6"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,5 @@
+v1.11.6 (19-09-2015)
+- Update to PVR addon API v4.1.0
 v1.11.5 (09-09-2015)
 - Updated to PVR API v4.0.0
 v1.11.4 (04-08-2015)

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -372,6 +372,7 @@ PVR_ERROR cPVRClientArgusTV::GetEpg(ADDON_HANDLE handle, const PVR_CHANNEL &chan
             broadcast.strWriter           = "";
             broadcast.iYear               = 0;
             broadcast.strIMDBNumber       = "";
+            broadcast.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
             PVR->TransferEpgEntry(handle, &broadcast);
           }


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075