### PR TITLE
Rename addon title to "ARGUS TV PVR Client Addon"

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -2,7 +2,7 @@
 <addon
   id="pvr.argustv"
   version="2.2.1"
-  name="ARGUS TV client"
+  name="ARGUS TV PVR Client Addon"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>


### PR DESCRIPTION
Suggestingthe renaming of addon title to "ARGUS TV PVR Client Addon" try try makes it a little more clear.