### PR TITLE
fix api version and avoid unclean kodi exit

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="2.4.2"
+  version="2.5.0"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -6,7 +6,7 @@
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.1.1"/>
+    <import addon="xbmc.pvr" version="5.2.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,7 @@
+v2.5.0 (20-09-2016)
+- Correct PVR API reference to v5.2.0
+- Disable unsubscribing from events (at least for v17 Krypton)
+  Allows clean exiting of Kodi
 v2.4.2 (20-08-2016)
 - Updated language files from Transifex
 v2.4.1 (18-06-2016)

--- a/src/EventsThread.cpp
+++ b/src/EventsThread.cpp
@@ -35,14 +35,8 @@ CEventsThread::CEventsThread(void) :
 CEventsThread::~CEventsThread(void)
 {
   XBMC->Log(LOG_DEBUG, "CEventsThread:: destructor");
-  if (m_subscribed)
-  {
-    int retval = ArgusTV::UnsubscribeServiceEvents(m_monitorId);
-    if (retval < 0)
-    {
-      XBMC->Log(LOG_NOTICE, "CEventsThread:: unsubscribe from events failed");
-    }
-  }
+  // v17 Krypton. When exiting Kodi with this addon still subscribed,
+  // network services are already unavailable. ArgusTV::UnsubscribeServiceEvents won't succeed
 }
 
 void CEventsThread::Connect()


### PR DESCRIPTION
This PR sets the PVR API version 5.2.0 which is missing in #53.

Also, when quitting Kodi, a network call to 'unsubscribe service events' causes an exception. Network services seem to be already unavailable when pvrmanger destroys the add-on. So, removing that call avoids it.

Either way the call will never succeed unless the user manually disables the add-on before quitting Kodi. And nobody wants to do that every time. Removing the call is user friendliest option for now I think, since AFAIK PVR add-ons can't get 'quit' announcements. Unless something changes in Kodi master.

[osx stacktrace](http://pastebin.com/1tz2hW9Q)
[kodi log](http://pastebin.com/vcQJadzF)
