### PR TITLE
support PVR API 5.7.0 changes

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="3.2.1"
+  version="3.3.0"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.0
+- Update to PVR addon API v5.7.0
+
 v3.2.0
 - Update to PVR addon API v5.5.0
 - Get rid of StdString

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -394,7 +394,6 @@ PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time
   return g_client->GetEpg(handle, channel, iStart, iEnd);
 }
 
-
 /*******************************************/
 /** PVR Channel Functions                 **/
 
@@ -560,11 +559,6 @@ long long LengthLiveStream(void)
   return g_client->LengthLiveStream();
 }
 
-bool SwitchChannel(const PVR_CHANNEL &channelinfo)
-{
-  return g_client->SwitchChannel(channelinfo);
-}
-
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
   return g_client->SignalStatus(signalStatus);
@@ -650,4 +644,9 @@ PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetEPGTagStreamProperties(const EPG_TAG*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 } //end extern "C"

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -114,6 +114,7 @@ private:
   void FreeChannels(std::vector<cChannel*> m_Channels);
   void Close();
   bool _OpenLiveStream(const PVR_CHANNEL &channel);
+  bool FindRecEntryUNC(const std::string &recId, std::string &recEntryURL);
 
   int                     m_iCurrentChannel;
   bool                    m_bConnected;
@@ -128,6 +129,7 @@ private:
   P8PLATFORM::CMutex        m_ChannelCacheMutex;
   std::vector<cChannel*>   m_TVChannels; // Local TV channel cache list needed for id to guid conversion
   std::vector<cChannel*>   m_RadioChannels; // Local Radio channel cache list needed for id to guid conversion
+  std::map <std::string, std::string> m_RecordingsMap; // <PVR_RECORDING.strRecordingId, URL of recording>
   int                     m_epg_id_offset;
   int                     m_signalqualityInterval;
   ArgusTV::CTsReader*     m_tsreader;


### PR DESCRIPTION
Completely blind attempt at a fix. Compiles, but cant runtime test. 

minimal support for PVR API 5.7.0 changes. Removed switchchannel functions
