### PR TITLE
add account info for smb shares

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="3.3.1"
+  version="3.3.2"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.2
+- Use account info for smb shares if added in settings
+
 v3.3.1
 - Bump jsoncpp to version 1.8.3
 

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -44,7 +44,9 @@
 #if !defined(TARGET_WINDOWS)
 #include <sys/time.h>
 #include "p8-platform/os.h"
+#if !defined(TARGET_DARWIN)
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+#endif
 #endif
 
 using namespace ADDON;

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -115,6 +115,7 @@ private:
   void Close();
   bool _OpenLiveStream(const PVR_CHANNEL &channel);
   bool FindRecEntryUNC(const std::string &recId, std::string &recEntryURL);
+  bool FindRecEntry(const std::string &recId, std::string &recEntryURL);
 
   int                     m_iCurrentChannel;
   bool                    m_bConnected;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -144,6 +144,27 @@ std::string ToCIFS(std::string& UNCName)
   return CIFSname;
 }
 
+bool InsertUser(std::string& UNCName)
+{
+  if (g_szUser.empty())
+    return false;
+
+  if (UNCName.find("smb://") == 0)
+  {
+    std::string SMBPrefix = "smb://" + g_szUser;
+
+    if (!g_szPass.empty())
+     SMBPrefix.append(":" + g_szPass);
+
+    SMBPrefix.append("@");
+
+    UNCName.replace(0, std::string("smb://").length(), SMBPrefix);
+    XBMC->Log(LOG_DEBUG, "Account Info added to SMB url");
+    return true;
+  }
+  return false;
+}
+
 
 // transform [smb://user:password@nascat/qrecordings/NCIS/2012-05-15_20-30_SBS 6_NCIS.ts]
 // into      [\\nascat\qrecordings\NCIS\2012-05-15_20-30_SBS 6_NCIS.ts]

--- a/src/utils.h
+++ b/src/utils.h
@@ -42,3 +42,5 @@ namespace BASE64
 std::string ToCIFS(std::string& UNCName);
 std::string ToUNC(std::string& CIFSName);
 std::string ToUNC(const char* CIFSName);
+bool InsertUser(std::string& UNCName);
+


### PR DESCRIPTION
adds account info to smb url's if user/pass set in settings

@ksooo Can you have a glance over this at some point. The helper in utils seems wrong in its approach, but i didnt want to delve deeper into ToCIFS, as that affects other methods in a bad way to slap on account info.

The user/pass settings were not used at all apart from setting them. Im guessing it just relied on shares to be open to everyone. With changes to a lot of things regarding smb (both windows and linux), this PR gets it working in my test environment.

I found on a win10 server for the backend (mac os client for kodi), that playback wouldnt work either without adding the account info. Didnt want to break backwards compat in case still running win7 or whatever and not using account info, hence the check on the empty user/pass or not before adding. Also, no other users mentioned this issue, so im not 100% about the _OpenLiveStream change. who really knows how people have this thing setup to function.

This backend is horrible to setup as well, but each to their own i guess.