### PR TITLE
jsoncpp1.8.3 deprecated function update

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="3.3.2"
+  version="3.3.3"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v3.3.3
+- Change to non deprecated jsoncpp methods
+
 v3.3.2
 - Use account info for smb shares if added in settings
 

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -751,8 +751,9 @@ PVR_ERROR cPVRClientArgusTV::DeleteRecording(const PVR_RECORDING &recinfo)
   XBMC->Log(LOG_DEBUG, "->DeleteRecording(%s == \"%s\")", recinfo.strRecordingId, UNCname.c_str());
   // JSONify the stream_url
   Json::Value recordingname (UNCname);
-  Json::FastWriter writer;
-  std::string jsonval = writer.write(recordingname);
+  Json::StreamWriterBuilder wbuilder;
+  std::string jsonval = Json::writeString(wbuilder, recordingname);
+
   if (ArgusTV::DeleteRecording(jsonval) >= 0)
   {
     // Trigger XBMC to update it's list
@@ -780,8 +781,8 @@ PVR_ERROR cPVRClientArgusTV::SetRecordingLastPlayedPosition(const PVR_RECORDING 
 
   // JSONify the stream_url
   Json::Value recordingname (recordingfilename);
-  Json::FastWriter writer;
-  std::string jsonval = writer.write(recordingname);
+  Json::StreamWriterBuilder wbuilder;
+  std::string jsonval = Json::writeString(wbuilder, recordingname);
   int retval = ArgusTV::SetRecordingLastWatchedPosition(jsonval, lastplayedposition);
   if (retval < 0)
   {
@@ -804,8 +805,8 @@ int cPVRClientArgusTV::GetRecordingLastPlayedPosition(const PVR_RECORDING &recin
   // JSONify the stream_url
   Json::Value response;
   Json::Value recordingname (recordingfilename);
-  Json::FastWriter writer;
-  std::string jsonval = writer.write(recordingname);
+  Json::StreamWriterBuilder wbuilder;
+  std::string jsonval = Json::writeString(wbuilder, recordingname);
   int retval = ArgusTV::GetRecordingLastWatchedPosition(jsonval, response);
   if (retval < 0)
   {
@@ -830,8 +831,8 @@ PVR_ERROR cPVRClientArgusTV::SetRecordingPlayCount(const PVR_RECORDING &recinfo,
 
   // JSONify the stream_url
   Json::Value recordingname (recordingfilename);
-  Json::FastWriter writer;
-  std::string jsonval = writer.write(recordingname);
+  Json::StreamWriterBuilder wbuilder;
+  std::string jsonval = Json::writeString(wbuilder, recordingname);
   int retval = ArgusTV::SetRecordingFullyWatchedCount(jsonval, playcount);
   if (retval < 0)
   {


### PR DESCRIPTION
This changes jsoncpp deprecated methods (Fastwriter, getformatederror, reader) to the
non deprecated versions.

If you can merge #76 first, and ill rebase and fixup the version/changelog on this one after.

Runtime tested on mac os with the changes from #76 applied to a win10 argustv server. No apparent regressions from my minimal testcases.