### PR TITLE
PVR API 6.2.0 Compatibility

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="4.1.0"
+  version="4.2.0"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v4.2.0
+- Update to PVR addon API v6.2.0
+
 v4.1.0
 - Update: Recompile for 6.1.0 PVR Addon API compatibility
 

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -360,7 +360,7 @@ PVR_ERROR cPVRClientArgusTV::GetEpg(ADDON_HANDLE handle, int iChannelUid, time_t
             broadcast.iGenreType          = EPG_GENRE_USE_STRING;
             broadcast.iGenreSubType       = 0;
             broadcast.strGenreDescription = epg.Genre();
-            broadcast.firstAired          = 0;
+            broadcast.strFirstAired       = "";
             broadcast.iParentalRating     = 0;
             broadcast.iStarRating         = 0;
             broadcast.iSeriesNumber       = 0;


### PR DESCRIPTION
This PR updates the pvr.argustv PVR addon for compatibility with the proposed PVR API v6.2.0 [Kodi PR 17182](https://github.com/xbmc/xbmc/pull/17192).

This addon only requires a trivial conversion of the EPG_TAG.firstAired field to adapt to it becoming a const char*.