### PR TITLE
fix windows build and add p8-platform to addon itself as depends

### DIFF
--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,0 +1,1 @@
+p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="4.1.0"
+  version="4.1.1"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,8 @@
+v4.1.1
+- Fix windows unicode GetTempPath parameters
+- Replace AppVeyor with Azure for test build (better performance)
+- Add p8-platform to own depends
+
 v4.1.0
 - Update: Recompile for 6.1.0 PVR Addon API compatibility
 

--- a/src/argustvrpc.cpp
+++ b/src/argustvrpc.cpp
@@ -33,9 +33,7 @@
 #include "argustvrpc.h"
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/util/StringUtils.h"
-#ifdef TARGET_WINDOWS_STORE
-#include "p8-platform/windows/CharsetConverter.h"
-#endif
+
 using namespace ADDON;
 
 // Some version dependent API strings
@@ -204,14 +202,8 @@ namespace ArgusTV
   std::string GetChannelLogo(const std::string& channelGUID)
   {
 #if defined(TARGET_WINDOWS)
-#if defined(TARGET_WINDOWS_STORE)
-    wchar_t wpath[MAX_PATH];
-    GetTempPath(MAX_PATH, wpath);
-    std::string tmppath = p8::windows::FromW(wpath);
-#else
     char tmppath[MAX_PATH];
-    GetTempPath(MAX_PATH, tmppath);
-#endif
+    GetTempPathA(MAX_PATH, tmppath);
 #elif defined(TARGET_LINUX) || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
     std::string tmppath = "/tmp/";
 #else


### PR DESCRIPTION
This is intended to significantly speed up the construction times for those who do not use these dependencies (most addons without this).

This will also happen to all other PVRs that need it and also allows you to add your own versions if necessary.

After converting this will be removed from Kodi.
Only used on the Matrix branches, the others remain with Kodi.