### PR TITLE
Remove p8platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,8 @@ project(pvr.argustv)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${PROJECT_SOURCE_DIR}/src)
 
 # Source files
@@ -60,7 +58,7 @@ endif(WIN32)
 # Make sure that CMake adds the headers to the MSVC project
 list(APPEND ARGUSTV_SOURCES ${ARGUSTV_HEADERS})
 
-set(DEPLIBS ${p8-platform_LIBRARIES} tsreader)
+set(DEPLIBS tsreader)
 
 find_package(JsonCpp REQUIRED)
 list(APPEND DEPLIBS ${JSONCPP_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,4 +70,11 @@ add_subdirectory(src/lib/tsreader)
 
 build_addon(pvr.argustv ARGUSTV DEPLIBS)
 
+# Temp workaround, this becomes later added to kodi-dev-kit system
+set_target_properties(pvr.argustv PROPERTIES
+    C_VISIBILITY_PRESET       hidden
+    CXX_VISIBILITY_PRESET     hidden
+    VISIBILITY_INLINES_HIDDEN YES
+)
+
 include(CPack)

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-argustv
 Priority: extra
 Maintainer: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
-Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
+Build-Depends: debhelper (>= 9.0.0), cmake, 
                kodi-addon-dev, libjsoncpp-dev
 Standards-Version: 4.1.2
 Section: libs

--- a/depends/common/p8-platform/p8-platform.txt
+++ b/depends/common/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/xbmc/platform.git cee64e9dc0b69e8d286dc170a78effaabfa09c44

--- a/depends/windowsstore/p8-platform/p8-platform.txt
+++ b/depends/windowsstore/p8-platform/p8-platform.txt
@@ -1,1 +1,0 @@
-p8-platform https://github.com/afedchin/platform.git win10

--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="6.0.1"
+  version="6.0.2"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,16 @@
+v6.0.2
+- Remove p8-platform dependency
+- Remove p8-platform OS includes
+- Use chrono to get millis time
+- Use std::mutex
+- Use kodi StringUtils
+- Remove SAFE_DELETE
+- Remove p8-platform time utils
+- Use chrono for timing
+- Use std::thread
+- Include windows.h for LARGE_INTEGER, MAX_PATH and GetTempAthA support
+- add temporary workaround about attribute hidden
+
 v6.0.1
 - Source rebuild trigger
 
@@ -139,7 +152,7 @@ v1.10.9 (29-06-2015)
 v1.10.8 (28-06-2015)
 - Updated language files from Transifex
 v1.10.7 (11-04-2015)
-- Added option for all recordings to be in folders 
+- Added option for all recordings to be in folders
 v1.10.6 (04-05-2015)
 - Updated to use new libplatform-dev
 v1.10.5 (09-04-2015)
@@ -223,8 +236,8 @@ v1.6.161 (12-12-2012)
 - New version number by Team XBMC
 v1.6.160.145 (11-12-2012)
 - Support ARGUS TV channel numbers on XBMC, switch on:
-  Settings / Live-TV / General / 
-    "Use backend channels..." and 
+  Settings / Live-TV / General /
+    "Use backend channels..." and
     "Always use the channel order..."
 - New version number by Team XBMC
 v1.0.150.144 (18-11-2012)
@@ -270,9 +283,9 @@ v0.0.1.134 (07-04-2012)
 v0.0.1.133 (31-03-2012)
 - The add-on now sets the time a recording was last watched on the server
 v0.0.1.132 (20-03-2012)
-- Small fix to correct one invalid GUID error message at start 
+- Small fix to correct one invalid GUID error message at start
 v0.0.1.131 (16-03-2012)
-- Added many internal verifications to the <FTR GUID> to <XBMC number> 
+- Added many internal verifications to the <FTR GUID> to <XBMC number>
   channel mappings. External factors can break the mapping and these
   checks will hopefully warn the user to reset the PVR database
 v0.0.1.130 (11-03-2012)
@@ -311,7 +324,7 @@ v0.0.1.117 (unreleased)
 - Adaptation to many changes within XBMC
 v0.0.1.116 (16-06-2011)
 - Greatly improved channel zapping
-- Add timer will now force a recording when no matching show title 
+- Add timer will now force a recording when no matching show title
   is found in the channel epg data on the server
 - Add timer fixed: new PVR API
 - GUI update triggers added: new PVR API
@@ -337,7 +350,7 @@ v0.0.1.109 (13-01-2011)
 - Initial support for retrieval of recordings on the ForTheRecord Argus server
 - Overview of recordings, grouped by Title
 - Viewing of a selected recording via the ForTheRecord shares
-- Fixes some memory corruptions 
+- Fixes some memory corruptions
 - Support for retrieval of recordings on the ForTheRecord Argus server
 - Overview of recordings, grouped by Title, including recording starttime, and description
 - Credits: Red-F

--- a/src/EventsThread.h
+++ b/src/EventsThread.h
@@ -8,24 +8,31 @@
 
 #pragma once
 
+#include <atomic>
+#include <thread>
+
 #include <json/json.h>
-#include <p8-platform/threads/threads.h>
 
 class cPVRClientArgusTV;
 
-class CEventsThread : public P8PLATFORM::CThread
+class CEventsThread
 {
 public:
   CEventsThread(cPVRClientArgusTV& instance);
-  ~CEventsThread(void);
+  ~CEventsThread();
   void Connect(void);
 
+  void StartThread();
+  void StopThread();
+
 private:
-  virtual void* Process(void);
+  void Process();
 
   void HandleEvents(Json::Value events);
 
   bool m_subscribed = false;
   std::string m_monitorId;
   cPVRClientArgusTV& m_instance;
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
 };

--- a/src/KeepAliveThread.cpp
+++ b/src/KeepAliveThread.cpp
@@ -23,22 +23,45 @@ CKeepAliveThread::CKeepAliveThread(cPVRClientArgusTV& instance) : m_instance(ins
 CKeepAliveThread::~CKeepAliveThread()
 {
   kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: destructor");
+  StopThread();
 }
 
-void* CKeepAliveThread::Process()
+void CKeepAliveThread::StartThread()
+{
+  kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: start");
+
+  if (!m_running)
+  {
+    m_running = true;
+    m_thread = std::thread([&] { Process(); });
+  }
+}
+
+void CKeepAliveThread::StopThread()
+{
+  kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: stop");
+  if (m_running)
+  {
+    m_running = false;
+    if (m_thread.joinable())
+      m_thread.join();
+  }
+}
+
+void CKeepAliveThread::Process()
 {
   kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: thread started");
-  while (!IsStopped())
+  while (m_running)
   {
     int retval = m_instance.GetRPC().KeepLiveStreamAlive();
     kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: KeepLiveStreamAlive returned %i", (int)retval);
-    // The new P8PLATFORM:: thread library has a problem with stopping a thread that is doing a long sleep
+
     for (int i = 0; i < 100; i++)
     {
-      if (Sleep(100))
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      if (!m_running)
         break;
     }
   }
   kodi::Log(ADDON_LOG_DEBUG, "CKeepAliveThread:: thread stopped");
-  return nullptr;
 }

--- a/src/KeepAliveThread.cpp
+++ b/src/KeepAliveThread.cpp
@@ -13,7 +13,6 @@
 #include "utils.h"
 
 #include <kodi/General.h>
-#include <p8-platform/os.h>
 
 CKeepAliveThread::CKeepAliveThread(cPVRClientArgusTV& instance) : m_instance(instance)
 {

--- a/src/KeepAliveThread.h
+++ b/src/KeepAliveThread.h
@@ -8,18 +8,24 @@
 
 #pragma once
 
-#include <p8-platform/threads/threads.h>
+#include <atomic>
+#include <thread>
 
 class cPVRClientArgusTV;
 
-class CKeepAliveThread : public P8PLATFORM::CThread
+class CKeepAliveThread
 {
 public:
   CKeepAliveThread(cPVRClientArgusTV& instance);
-  virtual ~CKeepAliveThread(void);
+  ~CKeepAliveThread();
+
+  void StartThread();
+  void StopThread();
 
 private:
-  virtual void* Process(void);
+  void Process();
 
   cPVRClientArgusTV& m_instance;
+  std::atomic<bool> m_running = {false};
+  std::thread m_thread;
 };

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -60,4 +60,7 @@ ADDON_STATUS CArgusTVAddon::SetSetting(const std::string& settingName,
   return m_settings.SetSetting(settingName, settingValue);
 }
 
+#pragma GCC visibility push(default) // Temp workaround, this becomes later added to kodi-dev-kit system
 ADDONCREATOR(CArgusTVAddon)
+#pragma GCC visibility pop
+

--- a/src/addon.h
+++ b/src/addon.h
@@ -15,7 +15,7 @@
 
 class cPVRClientArgusTV;
 
-class ATTRIBUTE_HIDDEN CArgusTVAddon : public kodi::addon::CAddonBase
+class CArgusTVAddon : public kodi::addon::CAddonBase
 {
 public:
   CArgusTVAddon() = default;

--- a/src/argustvrpc.cpp
+++ b/src/argustvrpc.cpp
@@ -29,6 +29,9 @@
 
 #include "lib/tsreader/platform.h"
 
+#if defined(TARGET_WINDOWS)
+#include <windows.h>
+#endif
 
 // Some version dependent API strings
 #define ATV_GETEPG_45 \

--- a/src/argustvrpc.cpp
+++ b/src/argustvrpc.cpp
@@ -22,9 +22,9 @@
 #include "utils.h"
 
 #include <kodi/Filesystem.h>
+#include <kodi/tools/StringUtils.h>
 #include <memory>
 #include <p8-platform/os.h>
-#include <p8-platform/util/StringUtils.h>
 #include <stdio.h>
 #include <sys/stat.h>
 
@@ -1149,7 +1149,7 @@ int CArgusTV::AddOneTimeSchedule(const std::string& channelid,
 
   // Fill relevant members
   std::string modifiedtitle = title;
-  StringUtils::Replace(modifiedtitle, "\"", "\\\"");
+  kodi::tools::StringUtils::Replace(modifiedtitle, "\"", "\\\"");
 
   newSchedule["KeepUntilMode"] = Json::Value(lifetimeToKeepUntilMode(lifetime));
   newSchedule["KeepUntilValue"] = Json::Value(lifetimeToKeepUntilValue(lifetime));
@@ -1238,7 +1238,7 @@ int CArgusTV::AddManualSchedule(const std::string& channelid,
 
   // Fill relevant members
   std::string modifiedtitle = title;
-  StringUtils::Replace(modifiedtitle, "\"", "\\\"");
+  kodi::tools::StringUtils::Replace(modifiedtitle, "\"", "\\\"");
 
   newSchedule["IsOneTime"] = Json::Value(true);
   newSchedule["KeepUntilMode"] = Json::Value(lifetimeToKeepUntilMode(lifetime));

--- a/src/argustvrpc.cpp
+++ b/src/argustvrpc.cpp
@@ -24,9 +24,10 @@
 #include <kodi/Filesystem.h>
 #include <kodi/tools/StringUtils.h>
 #include <memory>
-#include <p8-platform/os.h>
 #include <stdio.h>
 #include <sys/stat.h>
+
+#include "lib/tsreader/platform.h"
 
 
 // Some version dependent API strings

--- a/src/argustvrpc.cpp
+++ b/src/argustvrpc.cpp
@@ -56,7 +56,7 @@ int CArgusTV::ArgusTVRPC(const std::string& command,
                          const std::string& arguments,
                          std::string& json_response)
 {
-  P8PLATFORM::CLockObject critsec(m_communicationMutex);
+  std::lock_guard<std::mutex> critsec(m_communicationMutex);
   std::string url = m_baseURL + command;
   int retval = E_FAILED;
   kodi::Log(ADDON_LOG_DEBUG, "URL: %s\n", url.c_str());
@@ -96,7 +96,7 @@ int CArgusTV::ArgusTVRPCToFile(const std::string& command,
                                std::string& filename,
                                long& http_response)
 {
-  P8PLATFORM::CLockObject critsec(m_communicationMutex);
+  std::lock_guard<std::mutex> critsec(m_communicationMutex);
   std::string url = m_baseURL + command;
   int retval = E_FAILED;
   kodi::Log(ADDON_LOG_DEBUG, "URL: %s writing to file %s\n", url.c_str(), filename.c_str());

--- a/src/argustvrpc.h
+++ b/src/argustvrpc.h
@@ -10,7 +10,7 @@
 
 #include <cstdlib>
 #include <json/json.h>
-#include <p8-platform/threads/mutex.h>
+#include <mutex>
 #include <string>
 
 #define ATV_2_2_0 (60)
@@ -416,5 +416,5 @@ private:
   Json::Value m_currentLivestream;
 
   std::string m_baseURL;
-  P8PLATFORM::CMutex m_communicationMutex;
+  std::mutex m_communicationMutex;
 }; // class ArgusTV

--- a/src/lib/tsreader/CMakeLists.txt
+++ b/src/lib/tsreader/CMakeLists.txt
@@ -18,4 +18,10 @@ if(WIN32)
 endif()
 
 add_library(tsreader STATIC ${HEADERS} ${SOURCES})
-set_property(TARGET tsreader PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(tsreader PROPERTIES
+    C_VISIBILITY_PRESET       hidden
+    CXX_VISIBILITY_PRESET     hidden
+    VISIBILITY_INLINES_HIDDEN YES
+    POSITION_INDEPENDENT_CODE ON
+)
+

--- a/src/lib/tsreader/FileReader.cpp
+++ b/src/lib/tsreader/FileReader.cpp
@@ -25,9 +25,9 @@
 
 #include "FileReader.h"
 
-#include "p8-platform/util/timeutils.h" // for usleep
-
 #include <algorithm> //std::min, std::max
+#include <thread>
+
 #include <kodi/General.h>
 
 namespace ArgusTV
@@ -79,7 +79,7 @@ long FileReader::OpenFile()
 
     // Is this still needed on Windows?
     //CStdStringW strWFile = UTF8Util::ConvertUTF8ToUTF16(m_fileName.c_str());
-    usleep(20000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
   } while (--Tmo);
 
   if (Tmo)

--- a/src/lib/tsreader/FileReader.h
+++ b/src/lib/tsreader/FileReader.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "p8-platform/os.h"
-
 #include <kodi/Filesystem.h>
+
+#include "platform.h"
 
 namespace ArgusTV
 {

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -32,18 +32,9 @@
 #include <string>
 #include <thread>
 
-#if !defined(TARGET_WINDOWS)
-#include <sys/time.h>
-#if !defined(TARGET_DARWIN)
-#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
-#endif
-#endif
-
 #include <kodi/Filesystem.h>
 #include <kodi/General.h>
 #include <kodi/tools/EndTime.h>
-
-//using namespace P8PLATFORM;
 
 //Maximum time in msec to wait for the buffer file to become available - Needed for DVB radio (this sometimes takes some time)
 #define MAX_BUFFER_TIMEOUT 1500
@@ -398,7 +389,6 @@ long MultiFileReader::RefreshTSBufferFile()
       m_TSBufferFile.CloseFile();
       m_TSBufferFile.OpenFile();
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
     }
 
     if (Error)

--- a/src/lib/tsreader/MultiFileReader.cpp
+++ b/src/lib/tsreader/MultiFileReader.cpp
@@ -33,8 +33,6 @@
 #include <thread>
 
 #if !defined(TARGET_WINDOWS)
-#include "p8-platform/os.h"
-
 #include <sys/time.h>
 #if !defined(TARGET_DARWIN)
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -22,11 +22,18 @@
 
 #include "MultiFileReader.h"
 #include "p8-platform/os.h"
-#include "p8-platform/util/util.h"
 #include "utils.h"
 
 #include <kodi/General.h>
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
 namespace ArgusTV
 {
 CTsReader::CTsReader()
@@ -120,7 +127,7 @@ void CTsReader::Close()
   if (m_fileReader)
   {
     m_fileReader->CloseFile();
-    SAFE_DELETE(m_fileReader);
+    SafeDelete(m_fileReader);
   }
 }
 

--- a/src/lib/tsreader/TSReader.cpp
+++ b/src/lib/tsreader/TSReader.cpp
@@ -21,7 +21,6 @@
 #include "TSReader.h"
 
 #include "MultiFileReader.h"
-#include "p8-platform/os.h"
 #include "utils.h"
 
 #include <kodi/General.h>

--- a/src/lib/tsreader/TSReader.h
+++ b/src/lib/tsreader/TSReader.h
@@ -22,6 +22,10 @@
 
 #include "FileReader.h"
 
+#if defined(TARGET_WINDOWS)
+#include <windows.h>
+#endif
+
 namespace ArgusTV
 {
 class CTsReader

--- a/src/lib/tsreader/platform.h
+++ b/src/lib/tsreader/platform.h
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+/*
+ *************************************************************************
+ *  This file is a modified version from Team MediaPortal's
+ *  TsReader DirectShow filter
+ *  MediaPortal is a GPL'ed HTPC-Application
+ *  Copyright (C) 2005-2012 Team MediaPortal
+ *  http://www.team-mediaportal.com
+ *
+ * Changes compared to Team MediaPortal's version:
+ * - Code cleanup for PVR addon usage
+ * - Code refactoring for cross platform usage
+ *************************************************************************
+ *  This file originates from TSFileSource, a GPL directshow push
+ *  source filter that provides an MPEG transport stream output.
+ *  Copyright (C) 2005-2006 nate, bear
+ *  http://forums.dvbowners.com/
+ */
+
+#pragma once
+
+#include <kodi/Filesystem.h>
+
+#if (defined(_WIN32) || defined(_WIN64))
+
+#include <windows.h>
+#include <wchar.h>
+
+/* Handling of 2-byte Windows wchar strings */
+#define WcsLen wcslen
+#define WcsToMbs wcstombs
+typedef wchar_t Wchar_t; /* sizeof(wchar_t) = 2 bytes on Windows */
+
+#ifndef _SSIZE_T_DEFINED
+#ifdef  _WIN64
+typedef __int64    ssize_t;
+#else
+typedef _W64 int   ssize_t;
+#endif
+#define _SSIZE_T_DEFINED
+#endif
+
+/* Prevent deprecation warnings */
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
+#define strnicmp _strnicmp
+
+#else
+
+#include <string.h>
+#define strnicmp(X,Y,N) strncasecmp(X,Y,N)
+
+#if defined(__APPLE__)
+// for HRESULT
+#include <CoreFoundation/CFPlugInCOM.h>
+#endif
+
+typedef long LONG;
+#if !defined(__APPLE__)
+typedef LONG HRESULT;
+#endif
+
+#define _FILE_OFFSET_BITS 64
+#define FILE_BEGIN              0
+#define FILE_CURRENT            1
+#define FILE_END                2
+
+#ifndef S_OK
+#define S_OK           0L
+#endif
+
+#ifndef S_FALSE
+#define S_FALSE        1L
+#endif
+
+#ifndef FAILED
+#define FAILED(Status) ((HRESULT)(Status)<0)
+#endif
+
+#ifndef SUCCEEDED
+#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+#endif
+
+// Error codes
+#define ERROR_FILENAME_EXCED_RANGE 206L
+#define ERROR_INVALID_NAME         123L
+
+#ifndef E_OUTOFMEMORY
+#define E_OUTOFMEMORY              0x8007000EL
+#endif
+
+#ifndef E_FAIL
+#define E_FAIL                     0x8004005EL
+#endif
+
+#ifdef TARGET_LINUX
+#include <limits.h>
+#define MAX_PATH PATH_MAX
+#elif defined TARGET_DARWIN || defined __FreeBSD__
+#include <sys/syslimits.h>
+#define MAX_PATH PATH_MAX
+#else
+#define MAX_PATH 256
+#endif
+
+/* Handling of 2-byte Windows wchar strings on non-Windows targets
+ * Used by The MediaPortal and ForTheRecord pvr addons
+ */
+typedef uint16_t Wchar_t; /* sizeof(wchar_t) = 4 bytes on Linux, but the MediaPortal buffer files have 2-byte wchars */
+
+/* This is a replacement of the Windows wcslen() function which assumes that
+ * wchar_t is a 2-byte character.
+ * It is used for processing Windows wchar strings
+ */
+inline size_t WcsLen(const Wchar_t *str)
+{
+  const unsigned short *eos = (const unsigned short*)str;
+  while( *eos++ ) ;
+  return( (size_t)(eos - (const unsigned short*)str) -1);
+};
+
+/* This is a replacement of the Windows wcstombs() function which assumes that
+ * wchar_t is a 2-byte character.
+ * It is used for processing Windows wchar strings
+ */
+inline size_t WcsToMbs(char *s, const Wchar_t *w, size_t n)
+{
+  size_t i = 0;
+  const unsigned short *wc = (const unsigned short*) w;
+  while(wc[i] && (i < n))
+  {
+    s[i] = wc[i];
+    ++i;
+  }
+  if (i < n) s[i] = '\0';
+
+  return (i);
+};
+
+#endif

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -21,10 +21,10 @@
 #include "utils.h"
 
 #include <kodi/General.h>
+#include <chrono>
 #include <map>
 #include <thread>
 
-using namespace P8PLATFORM;
 using namespace ArgusTV;
 
 #define SIGNALQUALITY_INTERVAL 10
@@ -680,7 +680,7 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(bool deleted,
   m_RecordingsMap.clear();
 
   kodi::Log(ADDON_LOG_DEBUG, "RequestRecordingsList()");
-  int64_t t = GetTimeMs();
+  auto startTime = std::chrono::system_clock::now();
   retval = m_rpc.GetRecordingGroupByTitle(recordinggroupresponse);
   if (retval >= 0)
   {
@@ -749,8 +749,8 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(bool deleted,
       }
     }
   }
-  t = GetTimeMs() - t;
-  kodi::Log(ADDON_LOG_INFO, "Retrieving %d recordings took %d milliseconds.", iNumRecordings, t);
+  auto totalTime = std::chrono::system_clock::now() - startTime;
+  kodi::Log(ADDON_LOG_INFO, "Retrieving %d recordings took %d milliseconds.", iNumRecordings, std::chrono::duration_cast<std::chrono::milliseconds>(totalTime).count());
   return PVR_ERROR_NO_ERROR;
 }
 
@@ -1362,10 +1362,10 @@ bool cPVRClientArgusTV::_OpenLiveStream(const kodi::addon::PVRChannel& channelin
 
 bool cPVRClientArgusTV::OpenLiveStream(const kodi::addon::PVRChannel& channelinfo)
 {
-  int64_t t = GetTimeMs();
+  auto startTime = std::chrono::system_clock::now();
   bool rc = _OpenLiveStream(channelinfo);
-  t = GetTimeMs() - t;
-  kodi::Log(ADDON_LOG_INFO, "Opening live stream took %d milliseconds.", t);
+  auto totalTime = std::chrono::system_clock::now() - startTime;
+  kodi::Log(ADDON_LOG_INFO, "Opening live stream took %d milliseconds.", std::chrono::duration_cast<std::chrono::milliseconds>(totalTime).count());
   return rc;
 }
 

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -22,7 +22,8 @@
 
 #include <kodi/General.h>
 #include <map>
-#include <p8-platform/util/timeutils.h>
+#include <thread>
+
 #include <p8-platform/util/util.h>
 
 using namespace P8PLATFORM;
@@ -128,7 +129,7 @@ bool cPVRClientArgusTV::Connect()
         return false;
       default:
         kodi::Log(ADDON_LOG_ERROR, "Ping failed... No connection to Argus TV.");
-        usleep(1000000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         if (attemps > 3)
         {
           return false;
@@ -1326,7 +1327,7 @@ bool cPVRClientArgusTV::_OpenLiveStream(const kodi::addon::PVRChannel& channelin
     if (m_tsreader != nullptr)
     {
       //kodi::Log(ADDON_LOG_DEBUG, "Re-using existing TsReader...");
-      //usleep(5000000);
+      //std::this_thread::sleep_for(std::chrono::milliseconds(5000));
       //m_tsreader->OnZap();
       kodi::Log(ADDON_LOG_DEBUG, "Close existing and open new TsReader...");
       m_tsreader->Close();
@@ -1339,7 +1340,7 @@ bool cPVRClientArgusTV::_OpenLiveStream(const kodi::addon::PVRChannel& channelin
     m_tsreader->Open(filename.c_str());
     m_tsreader->OnZap();
     kodi::Log(ADDON_LOG_DEBUG, "Delaying %ld milliseconds.", m_base.GetSettings().TuneDelay());
-    usleep(1000 * m_base.GetSettings().TuneDelay());
+    std::this_thread::sleep_for(std::chrono::milliseconds(m_base.GetSettings().TuneDelay()));
     return true;
   }
   else
@@ -1380,7 +1381,7 @@ int cPVRClientArgusTV::ReadLiveStream(unsigned char* pBuffer, unsigned int iBuff
     long lRc = 0;
     if ((lRc = m_tsreader->Read(bufptr, read_wanted, &read_wanted)) > 0)
     {
-      usleep(400000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(400));
       read_timeouts++;
       kodi::Log(ADDON_LOG_INFO, "ReadLiveStream requested %d but only read %d bytes.", iBufferSize,
                 read_wanted);
@@ -1398,7 +1399,7 @@ int cPVRClientArgusTV::ReadLiveStream(unsigned char* pBuffer, unsigned int iBuff
       }
       bufptr += read_wanted;
       read_timeouts++;
-      usleep(40000);
+      std::this_thread::sleep_for(std::chrono::milliseconds(40));
     }
   }
 #if defined(ATV_DUMPTS)

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -24,8 +24,6 @@
 #include <map>
 #include <thread>
 
-#include <p8-platform/util/util.h>
-
 using namespace P8PLATFORM;
 using namespace ArgusTV;
 
@@ -33,6 +31,14 @@ using namespace ArgusTV;
 #define MAXLIFETIME \
   99 //Based on VDR addon and VDR documentation. 99=Keep forever, 0=can be deleted at any time, 1..98=days to keep
 
+template<typename T> void SafeDelete(T*& p)
+{
+  if (p)
+  {
+    delete p;
+    p = nullptr;
+  }
+}
 
 /************************************************************/
 /** Class interface */
@@ -1230,7 +1236,7 @@ void cPVRClientArgusTV::FreeChannels(std::vector<cChannel*> m_Channels)
 
   for (it = m_Channels.begin(); it < m_Channels.end(); it++)
   {
-    SAFE_DELETE(*it);
+    SafeDelete(*it);
   }
 }
 
@@ -1331,7 +1337,7 @@ bool cPVRClientArgusTV::_OpenLiveStream(const kodi::addon::PVRChannel& channelin
       //m_tsreader->OnZap();
       kodi::Log(ADDON_LOG_DEBUG, "Close existing and open new TsReader...");
       m_tsreader->Close();
-      SAFE_DELETE(m_tsreader);
+      SafeDelete(m_tsreader);
     }
     // Open Timeshift buffer
     // TODO: rtsp support
@@ -1464,7 +1470,7 @@ void cPVRClientArgusTV::CloseLiveStream()
       kodi::Log(ADDON_LOG_DEBUG, "ReadLiveStream: %I64d calls took %I64d nanoseconds.",
                 m_tsreader->sigmaCount(), m_tsreader->sigmaTime());
 #endif
-      SAFE_DELETE(m_tsreader);
+      SafeDelete(m_tsreader);
     }
     m_rpc.StopLiveStream();
     m_bTimeShiftStarted = false;
@@ -1565,12 +1571,12 @@ bool cPVRClientArgusTV::OpenRecordedStream(const kodi::addon::PVRRecording& reci
   {
     kodi::Log(ADDON_LOG_DEBUG, "Close existing TsReader...");
     m_tsreader->Close();
-    SAFE_DELETE(m_tsreader);
+    SafeDelete(m_tsreader);
   }
   m_tsreader = new CTsReader();
   if (m_tsreader->Open(UNCname.c_str()) != S_OK)
   {
-    SAFE_DELETE(m_tsreader);
+    SafeDelete(m_tsreader);
     return false;
   }
 
@@ -1589,7 +1595,7 @@ void cPVRClientArgusTV::CloseRecordedStream(void)
   {
     kodi::Log(ADDON_LOG_DEBUG, "Close TsReader");
     m_tsreader->Close();
-    SAFE_DELETE(m_tsreader);
+    SafeDelete(m_tsreader);
   }
 }
 

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -421,7 +421,7 @@ PVR_ERROR cPVRClientArgusTV::GetChannelsAmount(int& amount)
 
 PVR_ERROR cPVRClientArgusTV::GetChannels(bool radio, kodi::addon::PVRChannelsResultSet& results)
 {
-  CLockObject lock(m_ChannelCacheMutex);
+  std::lock_guard<std::mutex> lock(m_ChannelCacheMutex);
   Json::Value response;
   int retval = -1;
 
@@ -1197,7 +1197,7 @@ PVR_ERROR cPVRClientArgusTV::UpdateTimer(const kodi::addon::PVRTimer& timerinfo)
 /** Live stream handling */
 cChannel* cPVRClientArgusTV::FetchChannel(int channelid, bool LogError)
 {
-  CLockObject lock(m_ChannelCacheMutex);
+  std::lock_guard<std::mutex> lock(m_ChannelCacheMutex);
   cChannel* rc = FetchChannel(m_TVChannels, channelid, false);
   if (rc == nullptr)
     rc = FetchChannel(m_RadioChannels, channelid, false);

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -145,13 +145,7 @@ bool cPVRClientArgusTV::Connect()
 
   // Start service events monitor
   m_eventmonitor->Connect();
-  if (!m_eventmonitor->IsRunning())
-  {
-    if (!m_eventmonitor->CreateThread())
-    {
-      kodi::Log(ADDON_LOG_ERROR, "Start service monitor thread failed.");
-    }
-  }
+  m_eventmonitor->StartThread();
   m_bConnected = true;
   return true;
 }
@@ -163,13 +157,7 @@ void cPVRClientArgusTV::Disconnect()
   kodi::Log(ADDON_LOG_INFO, "Disconnect");
 
   // Stop service events monitor
-  if (m_eventmonitor->IsRunning())
-  {
-    if (!m_eventmonitor->StopThread())
-    {
-      kodi::Log(ADDON_LOG_ERROR, "Stop service monitor thread failed.");
-    }
-  }
+  m_eventmonitor->StopThread();
 
   if (m_bTimeShiftStarted)
   {
@@ -1318,13 +1306,7 @@ bool cPVRClientArgusTV::_OpenLiveStream(const kodi::addon::PVRChannel& channelin
     kodi::Log(ADDON_LOG_INFO, "Live stream file: %s", filename.c_str());
     m_bTimeShiftStarted = true;
     m_iCurrentChannel = channelinfo.GetUniqueId();
-    if (!m_keepalive->IsRunning())
-    {
-      if (!m_keepalive->CreateThread())
-      {
-        kodi::Log(ADDON_LOG_ERROR, "Start keepalive thread failed.");
-      }
-    }
+    m_keepalive->StartThread();
 
 #if defined(ATV_DUMPTS)
     if (ofd != -1)
@@ -1457,13 +1439,7 @@ void cPVRClientArgusTV::CloseLiveStream()
   std::string result;
   kodi::Log(ADDON_LOG_INFO, "CloseLiveStream");
 
-  if (m_keepalive->IsRunning())
-  {
-    if (!m_keepalive->StopThread())
-    {
-      kodi::Log(ADDON_LOG_ERROR, "Stop keepalive thread failed.");
-    }
-  }
+  m_keepalive->StopThread();
 
 #if defined(ATV_DUMPTS)
   if (ofd != -1)

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -18,7 +18,6 @@
 
 #include <kodi/addon-instance/PVR.h>
 #include <map>
-#include <p8-platform/os.h>
 #include <vector>
 
 namespace ArgusTV

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -124,7 +124,7 @@ private:
   time_t m_BackendUTCoffset = 0;
   time_t m_BackendTime = 0;
 
-  P8PLATFORM::CMutex m_ChannelCacheMutex;
+  std::mutex m_ChannelCacheMutex;
   std::vector<cChannel*>
       m_TVChannels; // Local TV channel cache list needed for id to guid conversion
   std::vector<cChannel*>

--- a/src/pvrclient-argustv.h
+++ b/src/pvrclient-argustv.h
@@ -27,7 +27,7 @@ class CTsReader;
 
 #undef ATV_DUMPTS
 
-class ATTRIBUTE_HIDDEN cPVRClientArgusTV : public kodi::addon::CInstancePVRClient
+class cPVRClientArgusTV : public kodi::addon::CInstancePVRClient
 {
 public:
   /* Class interface */

--- a/src/settings.h
+++ b/src/settings.h
@@ -18,7 +18,7 @@
 #define DEFAULT_TUNEDELAY 200
 #define DEFAULT_USEFOLDER false
 
-class ATTRIBUTE_HIDDEN CSettings
+class CSettings
 {
 public:
   CSettings() = default;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -13,8 +13,6 @@
 
 #include <kodi/General.h>
 
-#include <chrono>
-
 // --- cTimeMs ---------------------------------------------------------------
 
 cTimeMs::cTimeMs(int Ms)

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -12,9 +12,8 @@
 #include "tools.h"
 
 #include <kodi/General.h>
-#include <p8-platform/util/timeutils.h>
 
-using namespace P8PLATFORM;
+#include <chrono>
 
 // --- cTimeMs ---------------------------------------------------------------
 
@@ -23,70 +22,18 @@ cTimeMs::cTimeMs(int Ms)
   Set(Ms);
 }
 
-uint64_t cTimeMs::Now(void)
-{
-#if _POSIX_TIMERS > 0 && defined(_POSIX_MONOTONIC_CLOCK)
-#define MIN_RESOLUTION 5 // ms
-  static bool initialized = false;
-  static bool monotonic = false;
-  struct timespec tp;
-  if (!initialized)
-  {
-    // check if monotonic timer is available and provides enough accurate resolution:
-    if (clock_getres(CLOCK_MONOTONIC, &tp) == 0)
-    {
-      long Resolution = tp.tv_nsec;
-      // require a minimum resolution:
-      if (tp.tv_sec == 0 && tp.tv_nsec <= MIN_RESOLUTION * 1000000)
-      {
-        if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0)
-        {
-          kodi::Log(ADDON_LOG_DEBUG, "cTimeMs: using monotonic clock (resolution is %ld ns)",
-                    Resolution);
-          monotonic = true;
-        }
-        else
-          kodi::Log(ADDON_LOG_ERROR, "cTimeMs: clock_gettime(CLOCK_MONOTONIC) failed");
-      }
-      else
-        kodi::Log(ADDON_LOG_DEBUG,
-                  "cTimeMs: not using monotonic clock - resolution is too bad (%ld s %ld ns)",
-                  tp.tv_sec, tp.tv_nsec);
-    }
-    else
-      kodi::Log(ADDON_LOG_ERROR, "cTimeMs: clock_getres(CLOCK_MONOTONIC) failed");
-    initialized = true;
-  }
-  if (monotonic)
-  {
-    if (clock_gettime(CLOCK_MONOTONIC, &tp) == 0)
-      return (uint64_t(tp.tv_sec)) * 1000 + tp.tv_nsec / 1000000;
-    kodi::Log(ADDON_LOG_ERROR, "cTimeMs: clock_gettime(CLOCK_MONOTONIC) failed");
-    monotonic = false;
-    // fall back to gettimeofday()
-  }
-#else
-#if !defined(__WINDOWS__)
-#warning Posix monotonic clock not available
-#endif
-#endif
-  struct timeval t;
-  if (gettimeofday(&t, NULL) == 0)
-    return (uint64_t(t.tv_sec)) * 1000 + t.tv_usec / 1000;
-  return 0;
-}
-
 void cTimeMs::Set(int Ms)
 {
-  begin = Now() + Ms;
+  m_begin = std::chrono::steady_clock::now() + std::chrono::milliseconds(Ms);
 }
 
 bool cTimeMs::TimedOut(void)
 {
-  return Now() >= begin;
+  return std::chrono::steady_clock::now() >= m_begin;
 }
 
 uint64_t cTimeMs::Elapsed(void)
 {
-  return Now() - begin;
+  auto now = std::chrono::steady_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now - m_begin).count();
 }

--- a/src/tools.h
+++ b/src/tools.h
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <chrono>
+
 #define ERRNUL(e) \
   { \
     errno = e; \
@@ -41,12 +43,10 @@
 class cTimeMs
 {
 private:
-  uint64_t begin;
+  std::chrono::steady_clock::time_point m_begin;
 
 public:
   cTimeMs(int Ms = 0);
-  ///< Creates a timer with ms resolution and an initial timeout of Ms.
-  static uint64_t Now(void);
   void Set(int Ms = 0);
   bool TimedOut(void);
   uint64_t Elapsed(void);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm> // sort
 #include <kodi/General.h>
-#include <p8-platform/os.h>
 #include <string>
 
 namespace Json


### PR DESCRIPTION
v6.0.2
- Remove p8-platform dependency
- Remove p8-platform OS includes
- Use chrono to get millis time
- Use std::mutex
- Use kodi StringUtils
- Remove SAFE_DELETE
- Remove p8-platform time utils
- Use chrono for timing
- Use std::thread
- Include windows.h for LARGE_INTEGER, MAX_PATH and GetTempAthA support
- add temporary workaround about attribute hidden