### PR TITLE
fix wrong repo name on sync-addon-metadata-translations.yml

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   default:
-    if: github.repository == 'kodi-pvr/pvr.hts'
+    if: github.repository == 'kodi-pvr/pvr.argustv'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Independent request to have them first and hopefully the update about strings.po come soon.