### PR TITLE
Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="20.0.0"
+  version="20.1.0"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.0
+- Add supports recordings delete capability for PVR API 8.0.0
+
 v20.0.0
 - Update jsoncpp on depends to version 1.9.4
 - Translations updates from Weblate

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -75,6 +75,7 @@ PVR_ERROR cPVRClientArgusTV::GetCapabilities(kodi::addon::PVRCapabilities& capab
 
   capabilities.SetSupportsEPG(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsRecordingsUndelete(false);
   capabilities.SetSupportsTimers(true);
   capabilities.SetSupportsTV(true);


### PR DESCRIPTION
v20.1.0
- Add supports recordings delete capability for PVR API 8.0.0

@AlwinEsch here is an example of the change to make across the PVR add-ons. If an add-on has the `SupportsRecordings` then it should now also get the `SupportsRecordingsDelete` capability.

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395