### PR TITLE
- Add config option to display series and episode in recording title.

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="19.1.1"
+  version="19.2.0"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,7 @@
+v19.2.0
+- Add configuration option to add series and episode to recording title when available. 
+  This provides readable info as well as provides sorting by series, episode
+
 v19.1.1
 - Add EDL support for Recordings
 

--- a/pvr.argustv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.argustv/resources/language/resource.language.en_gb/strings.po
@@ -61,3 +61,7 @@ msgstr ""
 msgctxt "#30007"
 msgid "Single recordings in folder"
 msgstr ""
+
+msgctxt "#30008"
+msgid "Show series and episode in title when available"
+msgstr "Show series and episode in title when available"

--- a/pvr.argustv/resources/settings.xml
+++ b/pvr.argustv/resources/settings.xml
@@ -61,6 +61,11 @@
           <default>false</default>
           <control type="toggle"/>
         </setting>
+        <setting id="showseriesepisode" type="boolean" label="30008" help="-1">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
       </group>
     </category>
   </section>

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -732,7 +732,36 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(bool deleted,
                 recording.Transform(false);
                 tag.SetDirectory("");
               }
-              tag.SetTitle(recording.Title());
+
+              std::vector<std::string> titles = kodi::tools::StringUtils::Split(recording.Title(), " - "); 
+              std::string subTitle = "";
+              if (titles.size() > 1)
+                subTitle = titles[1];
+                
+              std::string displayTitle = recordinggroup.ProgramTitle();
+              //if user set configuration to show series and episode and series and episode exist, append them to the title
+              if (m_base.GetSettings().ShowSeriesEpisode() &&  recording.SeriesNumber() > 0 && recording.EpisodeNumber() > 0)
+              {
+                //left pad series and episode with zeros to allow proper sorting for series or episodes up to 99.
+                std::string series = std::to_string(recording.SeriesNumber());
+                if (recording.SeriesNumber() < 10)
+                  series = "S0" + series;
+                else
+                  series = "S" + series;
+
+                std::string episode = std::to_string(recording.EpisodeNumber());
+                if (recording.EpisodeNumber() < 10)
+                  episode = "E0" + episode;
+                else
+                  episode = "E" + episode;
+
+                displayTitle = displayTitle + " - " + series + episode;
+              }
+              if (subTitle.length() > 0)
+                displayTitle = displayTitle + " - " +  subTitle;
+              
+              tag.SetTitle(displayTitle);
+              /*tag.SetTitle(recording.Title());*/
               tag.SetPlotOutline(recording.SubTitle());
 
               m_RecordingsMap[tag.GetRecordingId()] = recording.RecordingFileName();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -84,6 +84,15 @@ bool CSettings::Load()
     m_bUseFolder = DEFAULT_USEFOLDER;
   }
 
+  /* Read setting "showseriesepisode" from settings.xml */
+  if (!kodi::CheckSettingBoolean("showseriesepisode", m_bShowSeriesEpisode))
+  {
+    /* If setting is unknown fallback to defaults */
+    kodi::Log(ADDON_LOG_ERROR,
+              "Couldn't get 'showseriesepisode' setting, falling back to 'false' as default");
+    m_bShowSeriesEpisode = DEFAULT_SHOWSERIESEPISODE;
+  }
+
   return true;
 }
 
@@ -145,6 +154,12 @@ ADDON_STATUS CSettings::SetSetting(const std::string& settingName,
     kodi::Log(ADDON_LOG_INFO, "Changed setting 'usefolder' from %u to %u", m_bUseFolder,
               settingValue.GetBoolean());
     m_bUseFolder = settingValue.GetBoolean();
+  }
+  else if (settingName == "showseriesepisode")
+  {
+    kodi::Log(ADDON_LOG_INFO, "Changed setting 'showseriesepisode' from %u to %u", m_bShowSeriesEpisode,
+              settingValue.GetBoolean());
+    m_bShowSeriesEpisode = settingValue.GetBoolean();
   }
 
   return ADDON_STATUS_OK;

--- a/src/settings.h
+++ b/src/settings.h
@@ -17,6 +17,7 @@
 #define DEFAULT_PASS ""
 #define DEFAULT_TUNEDELAY 200
 #define DEFAULT_USEFOLDER false
+#define DEFAULT_SHOWSERIESEPISODE false
 
 class CSettings
 {
@@ -39,6 +40,7 @@ public:
   const std::string& Pass() const { return m_szPass; }
   int TuneDelay() const { return m_iTuneDelay; }
   bool UseFolder() const { return m_bUseFolder; }
+  bool ShowSeriesEpisode() const { return m_bShowSeriesEpisode; }
 
 private:
   std::string m_szHostname = DEFAULT_HOST;
@@ -49,4 +51,5 @@ private:
   std::string m_szPass = DEFAULT_PASS;
   int m_iTuneDelay = DEFAULT_TUNEDELAY;
   bool m_bUseFolder = DEFAULT_USEFOLDER;
+  bool m_bShowSeriesEpisode = DEFAULT_SHOWSERIESEPISODE;
 };


### PR DESCRIPTION
I felt like there was a need to be able to sort by series and episode.  Since kodi doesn't offer an option to sort by series and episode. I figured adding them to the recording title would provide this sorting as well as provide additional useful information in the title.  I've added a new Boolean setting to enable/disable this option where it is disabled by default. The result will look like this:
Series Title - S##E## - Series Episode Title