### PR TITLE
- Don't set series and episode value if neither value is greater than zero

### DIFF
--- a/pvr.argustv/addon.xml.in
+++ b/pvr.argustv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="19.2.0"
+  version="19.2.1"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.argustv/changelog.txt
+++ b/pvr.argustv/changelog.txt
@@ -1,3 +1,6 @@
+v19.2.1
+- Don't set series and episode unless one of them has a value greater than zero
+
 v19.2.0
 - Update and standardize recording fields
   - Add series number

--- a/src/pvrclient-argustv.cpp
+++ b/src/pvrclient-argustv.cpp
@@ -708,8 +708,13 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(bool deleted,
             {
               kodi::addon::PVRRecording tag;
 
-              tag.SetSeriesNumber(recording.SeriesNumber());
-              tag.SetEpisodeNumber(recording.EpisodeNumber());
+              //There may be cases where series and/or episode are populated withe 0 by default
+              //if neither value is more than 0, there is no value to use or show them
+              if(recording.SeriesNumber() > 0 || recording.EpisodeNumber() > 0)
+              {
+                tag.SetSeriesNumber(recording.SeriesNumber());
+                tag.SetEpisodeNumber(recording.EpisodeNumber());
+              }
 
               tag.SetRecordingId(recording.RecordingId());
               tag.SetChannelName(recording.ChannelDisplayName());


### PR DESCRIPTION
I discovered that ArgusTV will default series number to 0 when not available. As a result, when series 0 is passed and no episode is passed, we get some strange title formatting where it will display "S0" and sometimes not have any white space after it.  Therefore, series and episode should only be populated if series or episode has a value greater than zero (which indicates it isn't just using a default number). 